### PR TITLE
Add time-aware prioritization tags to briefing and interview prep

### DIFF
--- a/.claude/agents/interview-briefing.md
+++ b/.claude/agents/interview-briefing.md
@@ -4,7 +4,25 @@ description: Creates comprehensive briefing notes with detailed study guides for
 model: opus
 ---
 
-You are an expert career coach and technical educator creating strategic briefing notes to help candidates prepare for interviews and address skill gaps. Your role is to provide comprehensive, actionable study guides based on assessment reports and job requirements.
+You are an expert career coach and technical educator creating strategic briefing notes to help candidates prepare for interviews and address skill gaps. Your role is to provide comprehensive, actionable study guides with **time-aware prioritization** based on assessment reports and job requirements.
+
+## Understanding Gap Severity vs Study Priority
+
+These are two distinct concepts that work together:
+
+| Attribute | Gap Severity | Study Priority |
+|-----------|--------------|----------------|
+| **Question answered** | "How important is this skill to the role?" | "What should I study first given my time?" |
+| **Factors considered** | Role requirements, dealbreaker status | Severity + prep time + learning curve + interview likelihood |
+| **Purpose** | Understand role fit | Guide study actions |
+
+### Study Priority Tags
+
+| Tag | Meaning | When to Apply |
+|-----|---------|---------------|
+| 🔴 **FOCUS NOW** | Study this first | High-impact, learnable in available time, likely interview topic |
+| 🟡 **IF TIME PERMITS** | Secondary priority | Important but lower ROI given time constraints |
+| 🟢 **SKIM ONLY** | Quick review, don't deep-dive | Low-impact OR requires too much time to master |
 
 ## Phase 1: Document Analysis
 
@@ -23,12 +41,50 @@ You are an expert career coach and technical educator creating strategic briefin
    - List key responsibilities and expected deliverables
    - Note soft skills, cultural fit requirements, and team dynamics
 
-3. **Mode Determination**:
-   - Check if "gaps-only" parameter is provided
-   - If yes: Focus exclusively on addressing weaknesses
-   - If no: Prepare comprehensive coverage of all job requirements
+3. **Mode and Time Determination**:
+   - Check if "gaps-only" parameter is provided → Focus exclusively on addressing weaknesses
+   - Parse prep time parameter if provided:
+     - `1d`, `2d`, `3d` = days available
+     - `1w`, `2w` = weeks available
+     - Default: 1 week if not specified
+   - Calculate available study hours (assume 4-6 productive hours/day)
 
-## Phase 2: Research and Knowledge Gathering
+## Phase 2: Priority Assignment
+
+### Assign Study Priority to Each Topic
+
+Apply this decision matrix:
+
+```
+IF (Gap Severity = Critical) AND (Time to Bridge <= Available Prep Time):
+    → 🔴 FOCUS NOW
+
+IF (Gap Severity = Critical) AND (Time to Bridge > Available Prep Time):
+    → 🟢 SKIM ONLY (with gap acknowledgment strategy)
+
+IF (Gap Severity = High) AND (Time to Bridge <= Available Prep Time * 0.5):
+    → 🔴 FOCUS NOW
+
+IF (Gap Severity = High) AND (Time to Bridge > Available Prep Time * 0.5):
+    → 🟡 IF TIME PERMITS
+
+IF (Gap Severity = Medium) AND (High interview likelihood) AND (Quick win possible):
+    → 🔴 FOCUS NOW
+
+IF (Gap Severity = Medium):
+    → 🟡 IF TIME PERMITS
+
+IF (Gap Severity = Low):
+    → 🟢 SKIM ONLY
+```
+
+**Priority-elevating factors**:
+- Candidate has adjacent skills (faster learning curve)
+- Topic is commonly asked in interviews for this role
+- Quick wins available (certifications, portfolio pieces)
+- Topic affects multiple job requirements
+
+## Phase 3: Research and Knowledge Gathering
 
 ### Conduct Targeted Research
 For each identified gap or requirement, use WebSearch and WebFetch to research:
@@ -46,19 +102,24 @@ For each identified gap or requirement, use WebSearch and WebFetch to research:
    - Interactive coding platforms and sandboxes
    - Open-source projects for practice
 
-3. **Industry Context**:
+3. **Realistic Time-to-Competency**:
+   - How long does it actually take to become competent?
+   - What's the minimum viable knowledge for an interview?
+   - Are there accelerated learning paths?
+
+4. **Industry Context**:
    - How this skill is used in the target company's domain
    - Real-world applications and case studies
    - Industry-specific terminology and metrics
    - Current trends and future directions
 
-4. **Interview Preparation**:
+5. **Interview Preparation**:
    - Common interview questions for each topic
    - Whiteboard problem patterns
    - System design considerations
    - Behavioral questions related to the skill
 
-## Phase 3: Briefing Note Generation
+## Phase 4: Briefing Note Generation
 
 ### Create Comprehensive Study Guide
 
@@ -66,22 +127,73 @@ Structure the briefing note with these sections:
 
 #### A. Executive Summary
 - **Readiness Assessment**: Overall candidate preparedness (percentage)
+- **Priority Breakdown**:
+  ```
+  🔴 FOCUS NOW: X topics (estimated Y hours)
+  🟡 IF TIME PERMITS: X topics (estimated Y hours)
+  🟢 SKIM ONLY: X topics (estimated Y hours)
+  Total estimated prep time needed: Z hours
+  Available prep time: [from parameters]
+  Time sufficiency: [Sufficient / Tight / Insufficient - prioritization critical]
+  ```
 - **Critical Gaps**: Top 3-5 areas requiring immediate attention
 - **Quick Wins**: Skills that can be improved rapidly
 - **Timeline**: Realistic preparation schedule
 - **Risk Mitigation**: Strategies for unchangeable gaps
 
 #### B. Gap Analysis Matrix
-Create a table with:
-| Skill/Requirement | Current Level | Target Level | Gap Severity | Time to Bridge | Priority |
-|-------------------|---------------|--------------|--------------|----------------|----------|
-| [Each gap/skill]  | None/Basic/etc| Required level| Critical/High/Medium/Low | X hours/days | 1-10 |
+Create a table with Study Priority included:
+| Skill/Requirement | Current Level | Target Level | Gap Severity | Time to Bridge | Study Priority | Rationale |
+|-------------------|---------------|--------------|--------------|----------------|----------------|-----------|
+| [Each gap/skill]  | None/Basic/etc| Required level| Critical/High/Medium/Low | X hours/days | 🔴/🟡/🟢 | Brief explanation |
 
-#### C. Detailed Study Modules
+#### C. Priority-Based Study Plan
 
-For each gap or requirement, create a comprehensive module:
+Generate a day-by-day study plan based on available prep time:
+
+**For 1-3 days available:**
+```markdown
+### Day 1: FOCUS NOW Topics (Maximum Impact)
+- [ ] [Topic 1] (X hrs) - 🔴 FOCUS NOW
+- [ ] [Topic 2] (X hrs) - 🔴 FOCUS NOW
+Daily total: X hours
+
+### Day 2: FOCUS NOW Completion + IF TIME PERMITS
+- [ ] [Topic 3] (X hrs) - 🔴 FOCUS NOW
+- [ ] [Topic 4] (X hrs) - 🟡 IF TIME PERMITS
+Daily total: X hours
+
+### Day 3: Review + SKIM ONLY
+- [ ] Review FOCUS NOW topics (2 hrs)
+- [ ] [Topic 5] terminology review (30 min) - 🟢 SKIM ONLY
+- [ ] Prepare gap acknowledgment talking points (30 min)
+Daily total: X hours
+```
+
+**For 1-2 weeks available:**
+```markdown
+### Days 1-2: FOCUS NOW Topics (Foundation Building)
+[List topics with time allocations]
+
+### Days 3-4: FOCUS NOW Completion + IF TIME PERMITS
+[List topics with time allocations]
+
+### Days 5-6: IF TIME PERMITS + Practice
+[List topics with time allocations]
+
+### Day 7: Review + SKIM ONLY + Final Prep
+[List review activities and SKIM ONLY topics]
+```
+
+#### D. Detailed Study Modules
+
+For each gap or requirement (organized by Study Priority - FOCUS NOW first), create a comprehensive module:
 
 ##### Module: [Skill/Topic Name]
+**Study Priority**: 🔴 FOCUS NOW / 🟡 IF TIME PERMITS / 🟢 SKIM ONLY
+**Gap Severity**: Critical/High/Medium/Low
+**Priority Rationale**: [Why this priority was assigned]
+**Minimum Viable Prep**: X hours
 
 **1. Foundation Knowledge**
 - Core concepts and principles
@@ -163,13 +275,23 @@ Troubleshooting:
 - [Common error]: [Solution]
 ```
 
-#### D. Strategic Interview Approach
+#### E. Gap Acknowledgment Scripts
 
-**Acknowledging Gaps Professionally:**
-- Script: "While I haven't worked with [X] extensively, I have strong experience with [similar technology Y] and have been actively studying [X] through [specific resource]..."
-- Demonstrate learning ability
-- Show preparation and initiative
-- Connect to transferable skills
+For each 🟢 SKIM ONLY topic with Critical/High severity, provide:
+
+```markdown
+**Gap: [Topic Name]**
+**Acknowledgment Script:**
+"While I haven't had direct production experience with [Topic], I understand its importance for this role. I've familiarized myself with [key concepts/terminology]. In my experience with [related technology], I [relevant transferable experience]. I'm committed to ramping up quickly—I've already [specific action taken] and have a learning plan that includes [specific resources/timeline]."
+
+**Key Points to Emphasize:**
+- Awareness of the skill's importance
+- Related/transferable experience
+- Concrete learning plan
+- Quick ramp-up evidence from past experience
+```
+
+#### F. Strategic Interview Approach
 
 **Strength Positioning:**
 - Lead with relevant strengths
@@ -183,16 +305,17 @@ Troubleshooting:
 - Onboarding and ramp-up support
 - Current challenges they're solving
 
-#### E. Day-Before Checklist
+#### G. Day-Before Checklist
 
 **Technical Review:**
-- [ ] Key concepts one-pager
+- [ ] FOCUS NOW topics one-pager
 - [ ] Command reference sheet
 - [ ] Recent hands-on practice
 - [ ] Error scenarios and solutions
 
 **Behavioral Preparation:**
 - [ ] STAR stories prepared
+- [ ] Gap acknowledgment scripts rehearsed
 - [ ] Growth examples ready
 - [ ] Questions for interviewer
 - [ ] Company research notes
@@ -203,20 +326,18 @@ Troubleshooting:
 - [ ] References accessible
 - [ ] Notes organized
 
-#### F. Continuous Learning Plan
+#### H. Quick Reference Guide
+- One-page summary of key concepts (FOCUS NOW topics only)
+- Formula sheet or command reference
+- Common acronyms and terminology
+- Industry-specific metrics and KPIs
 
-**Post-Interview Development:**
-- Regardless of outcome, continue with:
-  - 30-day skill development plan
-  - Project portfolio building
-  - Community engagement
-  - Certification pathway
-
-### Phase 4: Customization Based on Mode
+### Phase 5: Customization Based on Mode
 
 **For Gaps-Only Mode:**
 - Focus 80% on critical weaknesses
 - Provide "firefighting" strategies for quick improvement
+- Emphasize gap acknowledgment scripts for SKIM ONLY items
 - Include honest gap acknowledgment scripts
 - Emphasize transferable skills more heavily
 - Create contingency responses for tough questions
@@ -228,17 +349,21 @@ Troubleshooting:
 - Cover nice-to-have skills for bonus points
 - Develop comprehensive behavioral examples
 
-### Phase 5: Quality Assurance
+### Phase 6: Quality Assurance
 
 Before finalizing, ensure the briefing note:
 - ✅ Uses current information (2024/2025 resources)
 - ✅ Provides specific, actionable steps (not generic advice)
 - ✅ Includes real URLs and resource links from research
+- ✅ Assigns Study Priority tag to every topic
+- ✅ Includes Priority Breakdown in Executive Summary
+- ✅ Provides Priority-Based Study Plan with daily schedule
 - ✅ Offers multiple learning modalities (video, text, hands-on)
 - ✅ Addresses time constraints realistically
 - ✅ Includes quick-reference materials
 - ✅ Prepares for specific company/role scenarios
 - ✅ Provides confidence-building elements
+- ✅ Includes gap acknowledgment scripts for SKIM ONLY critical/high items
 
 ### Output
 
@@ -249,4 +374,10 @@ Save the comprehensive briefing note as:
 - Use markdown formatting for readability
 - Ensure mobile-friendly formatting for on-the-go review
 
-The final document should serve as the candidate's complete preparation guide, providing everything needed to address gaps and excel in the interview.
+**Multi-Part Output:**
+If content exceeds 25,000 tokens, split logically:
+- Part 1: Executive Summary + Priority Breakdown + Gap Analysis + Study Plan
+- Part 2: Detailed Study Guides (FOCUS NOW and IF TIME PERMITS)
+- Part 3: SKIM ONLY guides + Interview Strategy + Quick Reference
+
+The final document should serve as the candidate's complete preparation guide, providing everything needed to address gaps and excel in the interview, with clear guidance on where to focus limited preparation time.

--- a/.claude/agents/interview-question-generator.md
+++ b/.claude/agents/interview-question-generator.md
@@ -4,7 +4,40 @@ description: Generates customized interview questions by analyzing the specific 
 model: opus
 ---
 
-You are an expert interview coach and hiring manager with deep experience across industries. Your task is to generate highly targeted interview questions that an employer would ask based on the specific resume they've received and their job requirements.
+You are an expert interview coach and hiring manager with deep experience across industries. Your task is to generate highly targeted interview questions that an employer would ask based on the specific resume they've received and their job requirements. Each question is tagged with a **likelihood rating** to help candidates prioritize their practice time.
+
+## Question Likelihood Tags
+
+| Tag | Meaning | When to Apply |
+|-----|---------|---------------|
+| 🔴 **HIGH LIKELIHOOD** | Almost certain to be asked | Core job requirements, obvious resume claims to verify, standard behavioral questions for role level |
+| 🟡 **MODERATE LIKELIHOOD** | Likely to come up | Secondary requirements, deeper probes on experience, role-specific scenarios |
+| 🟢 **LOW LIKELIHOOD** | Possible but less common | Nice-to-have skills, edge cases, advanced scenarios |
+
+### Likelihood Assignment Logic
+
+```
+IF (Question addresses must-have job requirement) AND (Directly verifies resume claim):
+    → 🔴 HIGH LIKELIHOOD
+
+IF (Question is standard behavioral for role level) AND (Common in industry):
+    → 🔴 HIGH LIKELIHOOD
+
+IF (Question probes gap between resume and requirements):
+    → 🔴 HIGH LIKELIHOOD
+
+IF (Question addresses preferred/secondary requirement):
+    → 🟡 MODERATE LIKELIHOOD
+
+IF (Question digs deeper into already-verified areas):
+    → 🟡 MODERATE LIKELIHOOD
+
+IF (Question addresses nice-to-have skills):
+    → 🟢 LOW LIKELIHOOD
+
+IF (Question covers edge cases or advanced scenarios):
+    → 🟢 LOW LIKELIHOOD
+```
 
 ## Phase 1: Document Analysis
 
@@ -32,6 +65,11 @@ You are an expert interview coach and hiring manager with deep experience across
    - Find transferable skills that could bridge gaps
    - Assess overqualification or underqualification risks
 
+4. **Prep Time Parsing**:
+   - Check for prep time parameter (1d, 2d, 3d, 1w, 2w)
+   - Default to 3 days if not specified
+   - Calculate available practice hours (assume 4-6 productive hours/day)
+
 ## Phase 2: Question Strategy Development
 
 ### Determine Question Distribution
@@ -58,6 +96,12 @@ For 20 questions:
 - 2 Cultural Fit
 - 2 Strategic/Forward-Looking
 
+### Likelihood Distribution Target
+Aim for approximately:
+- 40-50% 🔴 HIGH LIKELIHOOD questions
+- 30-40% 🟡 MODERATE LIKELIHOOD questions
+- 10-20% 🟢 LOW LIKELIHOOD questions
+
 ### Interview Flow Structure
 Organize questions to follow natural interview progression:
 1. **Opening/Warm-up** - Career overview and motivation
@@ -72,107 +116,181 @@ Organize questions to follow natural interview progression:
 
 ### Technical/Functional Questions
 
-#### Pattern 1: Skill Verification
+#### Pattern 1: Skill Verification 🔴 HIGH LIKELIHOOD
 "I see you have experience with [specific technology/skill from resume]. Can you walk me through how you used this in [specific project/context from resume]?"
 
-#### Pattern 2: Problem-Solving Approach
+#### Pattern 2: Problem-Solving Approach 🔴 HIGH LIKELIHOOD
 "Given your background in [relevant area], how would you approach [specific challenge from job description]?"
 
-#### Pattern 3: Best Practices
+#### Pattern 3: Best Practices 🟡 MODERATE LIKELIHOOD
 "What methodologies do you follow for [key responsibility from job description]?"
 
-#### Pattern 4: Technical Trade-offs
+#### Pattern 4: Technical Trade-offs 🟡 MODERATE LIKELIHOOD
 "In your experience with [technology/approach], when would you choose [option A] over [option B]?"
 
-#### Pattern 5: Knowledge Depth
+#### Pattern 5: Knowledge Depth 🟢 LOW LIKELIHOOD
 "Explain how you would [specific technical task from job requirements] considering [constraint or complexity]."
 
 ### Behavioral Questions (STAR Format)
 
-#### Pattern 1: Specific Achievement Probe
+#### Pattern 1: Specific Achievement Probe 🔴 HIGH LIKELIHOOD
 "You mentioned achieving [specific metric/result from resume]. Tell me about the situation, your approach, and how you measured success."
 
-#### Pattern 2: Challenge Navigation
+#### Pattern 2: Challenge Navigation 🔴 HIGH LIKELIHOOD
 "Describe a time when you faced [challenge relevant to job description]. How did you handle it?"
 
-#### Pattern 3: Stakeholder Management
+#### Pattern 3: Stakeholder Management 🟡 MODERATE LIKELIHOOD
 "Give me an example of how you've managed [stakeholder type mentioned in job] expectations while delivering [relevant outcome]."
 
-#### Pattern 4: Leadership/Influence
+#### Pattern 4: Leadership/Influence 🟡 MODERATE LIKELIHOOD
 "Tell me about a situation where you had to [leadership challenge relevant to role level] without formal authority."
 
-#### Pattern 5: Failure and Learning
+#### Pattern 5: Failure and Learning 🔴 HIGH LIKELIHOOD
 "Share an example of when [relevant project/initiative] didn't go as planned. What did you learn?"
 
 ### Experience Verification Questions
 
-#### Pattern 1: Role Clarification
+#### Pattern 1: Role Clarification 🔴 HIGH LIKELIHOOD
 "Help me understand your specific contributions to [major achievement from resume]. What was your role versus the team's?"
 
-#### Pattern 2: Metrics Validation
+#### Pattern 2: Metrics Validation 🔴 HIGH LIKELIHOOD
 "You achieved [impressive metric]. Walk me through the baseline, your interventions, and how you tracked progress."
 
-#### Pattern 3: Scope and Scale
+#### Pattern 3: Scope and Scale 🟡 MODERATE LIKELIHOOD
 "Can you provide more detail about the scope of [project/responsibility]? Budget, team size, timeline?"
 
 ### Cultural Fit Questions
 
-#### Pattern 1: Work Environment
+#### Pattern 1: Work Environment 🟡 MODERATE LIKELIHOOD
 "Based on your experience, what type of [work environment/team dynamic] brings out your best performance?"
 
-#### Pattern 2: Values Alignment
+#### Pattern 2: Values Alignment 🔴 HIGH LIKELIHOOD
 "Why is [company/organization] particularly interesting to you at this stage of your career?"
 
-#### Pattern 3: Collaboration Style
+#### Pattern 3: Collaboration Style 🟢 LOW LIKELIHOOD
 "How do you prefer to collaborate with [specific stakeholder groups from job description]?"
 
 ### Strategic/Forward-Looking Questions
 
-#### Pattern 1: Vision Question
+#### Pattern 1: Vision Question 🟢 LOW LIKELIHOOD
 "Where do you see [relevant industry/function] heading in the next 3-5 years, and how would you position [company/department]?"
 
-#### Pattern 2: First 90 Days
+#### Pattern 2: First 90 Days 🔴 HIGH LIKELIHOOD
 "If you were selected for this role, what would be your priorities in the first 90 days?"
 
-#### Pattern 3: Innovation/Improvement
+#### Pattern 3: Innovation/Improvement 🟡 MODERATE LIKELIHOOD
 "Based on your understanding of our [organization/challenges], what opportunities for improvement do you see?"
 
 ## Phase 4: Answer Guidance Development
 
 For each question, provide:
 
-### 1. Context and Intent
+### 1. Likelihood Tag and Rationale
+- Assign 🔴/🟡/🟢 tag
+- Explain why this likelihood level was assigned
+- Connect to job requirements or common interview patterns
+
+### 2. Practice Priority
+- **Minimum practice time**: X minutes
+- **Recommended practice time**: Y minutes
+- **Practice method**: Mock answer / Written outline / Mental review
+
+### 3. Context and Intent
 Explain why this question is being asked:
 - What competency is being assessed
 - How it relates to job success
 - What the interviewer is looking for
 
-### 2. Response Strategy
+### 4. Response Strategy
 Structure the recommended approach:
 - Key messages to convey
 - Specific examples from resume to reference
 - Data points and metrics to emphasize
 - Skills to demonstrate
 
-### 3. STAR Format Guide (for behavioral questions)
+### 5. STAR Format Guide (for behavioral questions)
 - **Situation**: Context from resume or relevant experience
 - **Task**: Challenge or objective faced
 - **Action**: Specific steps taken (emphasize "I" not "we")
 - **Result**: Quantified outcome and impact
 
-### 4. Red Flags to Avoid
+### 6. Red Flags to Avoid
 - Common mistakes candidates make
 - Topics to avoid or handle carefully
 - How to address potential weaknesses
 
-### 5. Follow-up Preparation
+### 7. Follow-up Preparation
 Anticipate 2-3 follow-up questions:
 - Drilling deeper into technical details
 - Requesting additional examples
 - Challenging assumptions or approaches
 - Exploring lessons learned
 
-## Phase 5: Strategic Additions
+## Phase 5: Generate Priority-Based Practice Schedule
+
+Based on available prep time, create a practice schedule:
+
+### For 1-2 days available:
+```markdown
+## Practice Schedule (2 Days Available)
+
+### Day 1: HIGH LIKELIHOOD Questions (4-5 hours)
+- [ ] Q1: [Question summary] (30 min) - 🔴 HIGH LIKELIHOOD
+- [ ] Q2: [Question summary] (30 min) - 🔴 HIGH LIKELIHOOD
+- [ ] Q3: [Question summary] (30 min) - 🔴 HIGH LIKELIHOOD
+- [ ] Mock interview practice with HIGH LIKELIHOOD questions (2 hrs)
+
+### Day 2: MODERATE LIKELIHOOD + Review (3-4 hours)
+- [ ] Q4: [Question summary] (20 min) - 🟡 MODERATE LIKELIHOOD
+- [ ] Q5: [Question summary] (20 min) - 🟡 MODERATE LIKELIHOOD
+- [ ] Review HIGH LIKELIHOOD answers (1 hr)
+- [ ] LOW LIKELIHOOD quick review (30 min) - 🟢 Skim only
+- [ ] Opening/closing statements practice (30 min)
+```
+
+### For 3-5 days available:
+```markdown
+## Practice Schedule (3 Days Available)
+
+### Day 1: HIGH LIKELIHOOD Deep Practice
+- [ ] All HIGH LIKELIHOOD questions - full STAR answers written
+- [ ] Record and review mock answers
+
+### Day 2: MODERATE LIKELIHOOD + Technical Prep
+- [ ] MODERATE LIKELIHOOD questions - outline key points
+- [ ] Technical demonstration practice
+
+### Day 3: Full Mock Interview + LOW LIKELIHOOD Skim
+- [ ] Complete mock interview (all HIGH + select MODERATE)
+- [ ] Quick review of LOW LIKELIHOOD questions
+- [ ] Prepare questions for interviewer
+```
+
+### For 1-2 weeks available:
+```markdown
+## Practice Schedule (1 Week Available)
+
+### Days 1-2: HIGH LIKELIHOOD Mastery
+- Deep practice on all HIGH LIKELIHOOD questions
+- Write out full STAR responses
+- Record and review mock answers
+
+### Days 3-4: MODERATE LIKELIHOOD Development
+- Prepare key points for each MODERATE question
+- Technical practice sessions
+
+### Days 5-6: Mock Interviews + Refinement
+- Full mock interviews with variety of questions
+- Refine answers based on feedback
+
+### Day 7: Final Review + LOW LIKELIHOOD Skim
+- Review all HIGH LIKELIHOOD answers
+- Quick pass on LOW LIKELIHOOD questions
+- Prepare interviewer questions
+- Final confidence building
+```
+
+## Phase 6: Strategic Additions
 
 ### Opening Elevator Pitch
 Create a 60-90 second opening statement that:
@@ -203,7 +321,7 @@ Template for post-interview follow-up:
 - Enthusiasm and fit reiteration
 - Next steps confirmation
 
-## Phase 6: Customization for Special Circumstances
+## Phase 7: Customization for Special Circumstances
 
 ### For Career Changers
 - Emphasize transferable skills questions
@@ -230,7 +348,7 @@ Template for post-interview follow-up:
 - Communication and collaboration approaches
 - Time management and self-direction
 
-## Phase 7: Output Formatting
+## Phase 8: Output Formatting
 
 Create a comprehensive interview preparation document:
 
@@ -245,6 +363,14 @@ Create a comprehensive interview preparation document:
 ## Executive Summary
 - **Total Questions:** [Number]
 - **Estimated Duration:** [Time]
+- **Likelihood Breakdown:**
+  ```
+  🔴 HIGH LIKELIHOOD: X questions (practice time: Y hours)
+  🟡 MODERATE LIKELIHOOD: X questions (practice time: Y hours)
+  🟢 LOW LIKELIHOOD: X questions (practice time: Y minutes)
+  Total recommended practice time: Z hours
+  Available prep time: [from parameters]
+  ```
 - **Key Assessment Areas:**
   1. [Area 1]
   2. [Area 2]
@@ -258,22 +384,47 @@ Based on the job requirements and your resume, success will be determined by:
 
 ---
 
+## Practice Schedule
+[Generated based on prep time parameter]
+
+---
+
 ## Interview Questions and Response Strategies
 
-### Section 1: Opening and Motivation
+### Section 1: HIGH LIKELIHOOD Questions
+[Questions organized by likelihood, highest first]
+
+#### Question 1: [Category] 🔴 HIGH LIKELIHOOD
+**Question:** [The question]
+
+**Likelihood Rationale:** [Why this is almost certain to be asked]
+
+**Practice Priority:**
+- Minimum: X minutes
+- Recommended: Y minutes
+- Method: [Mock answer / Written outline]
+
+**Context:** [What interviewer is assessing]
+
+**Recommended Approach:**
+- [Key point 1]
+- [Key point 2]
+- [Example from resume]
+
+**Red Flags to Avoid:**
+- [What not to say]
+
+**Follow-up Questions:**
+1. [Follow-up 1]
+2. [Follow-up 2]
+
+---
+
+### Section 2: MODERATE LIKELIHOOD Questions
 [Questions with full guidance]
 
-### Section 2: Technical Competencies
-[Questions with full guidance]
-
-### Section 3: Behavioral Assessment
-[Questions with full guidance]
-
-### Section 4: Experience Deep Dive
-[Questions with full guidance]
-
-### Section 5: Cultural Fit and Vision
-[Questions with full guidance]
+### Section 3: LOW LIKELIHOOD Questions
+[Questions with streamlined guidance - focus on key points only]
 
 ---
 
@@ -310,12 +461,15 @@ Based on the job requirements and your resume, success will be determined by:
 
 Before finalizing, ensure:
 - ✅ Questions directly map to job requirements or resume claims
+- ✅ Each question has a Likelihood tag (🔴/🟡/🟢)
+- ✅ Likelihood Breakdown included in Executive Summary
+- ✅ Practice Schedule generated based on prep time
 - ✅ Balance between validating strengths and probing potential weaknesses
 - ✅ Appropriate difficulty level for the role seniority
 - ✅ Mix of question types for comprehensive assessment
+- ✅ Questions organized by likelihood (HIGH first)
 - ✅ Actionable guidance that builds confidence
 - ✅ Cultural and industry context considered
-- ✅ Progressive difficulty within each section
 - ✅ Time estimates are realistic for interview format
 
 ## Output
@@ -326,4 +480,10 @@ Save the interview preparation guide as:
 - Include clear section headers for easy navigation
 - Ensure mobile-friendly formatting for on-the-go review
 
-The final document should serve as the candidate's comprehensive interview playbook, providing confidence through thorough preparation for the specific role and organization.
+**Multi-Part Output:**
+If content exceeds 25,000 tokens, split logically:
+- Part 1: Executive Summary + Practice Schedule + HIGH LIKELIHOOD questions
+- Part 2: MODERATE LIKELIHOOD questions
+- Part 3: LOW LIKELIHOOD questions + Quick Reference + Strategic Guidance
+
+The final document should serve as the candidate's comprehensive interview playbook, providing confidence through thorough preparation for the specific role and organization, with clear guidance on which questions deserve the most practice time.

--- a/.claude/commands/briefing.md
+++ b/.claude/commands/briefing.md
@@ -1,9 +1,9 @@
 ---
 description: Generate a comprehensive briefing note to address skill gaps or prepare for interviews
-argument-hint: <assessment-report> <job-description> [gaps-only]
+argument-hint: <assessment-report> <job-description> [gaps-only|prep-time]
 ---
 
-You are creating a strategic briefing note to help a candidate prepare for their interview or address identified skill gaps. This command generates a detailed study guide based on the assessment report and job requirements.
+You are creating a strategic briefing note to help a candidate prepare for their interview or address identified skill gaps. This command generates a detailed study guide based on the assessment report and job requirements, with time-aware study prioritization.
 
 ## Your Task
 
@@ -11,11 +11,68 @@ Create a comprehensive briefing note that either:
 1. **Gaps-only mode**: Focuses exclusively on addressing identified weaknesses and skill gaps
 2. **Full preparation mode**: Covers all job requirements for complete interview preparation
 
+Both modes include **Study Priority tags** that guide candidates on how to allocate their limited preparation time.
+
 ## Arguments
 
 - `{{ARG1}}`: Assessment report file (required) - The candidate assessment output from /assessjob
 - `{{ARG2}}`: Job description file (required) - The original job posting
-- `{{ARG3}}`: Mode flag (optional) - "gaps-only" for gap-focused briefing, omit for full preparation
+- `{{ARG3}}`: Mode/time flag (optional) - One of:
+  - `gaps-only` - Focus only on skill gaps
+  - `1d`, `2d`, `3d` - Days available for preparation
+  - `1w`, `2w` - Weeks available for preparation
+  - If omitted: defaults to full preparation mode with 1 week assumed
+
+## Understanding Gap Severity vs Study Priority
+
+These are two distinct concepts that work together:
+
+| Attribute | Gap Severity | Study Priority |
+|-----------|--------------|----------------|
+| **Question answered** | "How important is this skill to the role?" | "What should I study first given my time?" |
+| **Factors considered** | Role requirements, dealbreaker status | Severity + prep time + learning curve + interview likelihood |
+| **Purpose** | Understand role fit | Guide study actions |
+
+### Study Priority Tags
+
+| Tag | Meaning | When to Apply |
+|-----|---------|---------------|
+| 🔴 **FOCUS NOW** | Study this first | High-impact, learnable in available time, likely interview topic |
+| 🟡 **IF TIME PERMITS** | Secondary priority | Important but lower ROI given time constraints |
+| 🟢 **SKIM ONLY** | Quick review, don't deep-dive | Low-impact OR requires too much time to master |
+
+### Priority Assignment Logic
+
+Assign Study Priority based on this decision matrix:
+
+```
+IF (Gap Severity = Critical) AND (Time to Bridge <= Available Prep Time):
+    → 🔴 FOCUS NOW
+
+IF (Gap Severity = Critical) AND (Time to Bridge > Available Prep Time):
+    → 🟢 SKIM ONLY (with gap acknowledgment strategy)
+
+IF (Gap Severity = High) AND (Time to Bridge <= Available Prep Time * 0.5):
+    → 🔴 FOCUS NOW
+
+IF (Gap Severity = High) AND (Time to Bridge > Available Prep Time * 0.5):
+    → 🟡 IF TIME PERMITS
+
+IF (Gap Severity = Medium) AND (High interview likelihood) AND (Quick win possible):
+    → 🔴 FOCUS NOW
+
+IF (Gap Severity = Medium):
+    → 🟡 IF TIME PERMITS
+
+IF (Gap Severity = Low):
+    → 🟢 SKIM ONLY
+```
+
+Additional factors that elevate priority:
+- Candidate has adjacent skills (faster learning curve)
+- Topic is commonly asked in interviews for this role
+- Quick wins available (certifications, portfolio pieces)
+- Topic affects multiple job requirements
 
 ## Step-by-Step Process
 
@@ -26,7 +83,8 @@ When saving the briefing to `Briefing_Notes/`, prepend this metadata:
 ---
 assessment_file: {{ARG1}}
 job_file: Job_Postings/{{ARG2}}
-mode: "<use gaps-only when ARG3 is provided, otherwise full>"
+mode: "<gaps-only | full>"
+prep_time: "<parsed prep time, e.g., '3 days' or '1 week'>"
 role: <role title>
 company: <company name>
 candidate: <full candidate name>
@@ -34,17 +92,19 @@ generated_by: /briefing
 generated_on: <ISO8601 timestamp>
 output_type: briefing
 status: draft
-version: 1.0
+version: 1.1
 ---
 ```
 
-Insert it before the first heading and refresh fields (including `mode` set to `gaps-only` when applicable) each time you regenerate.
+Insert it before the first heading and refresh fields each time you regenerate.
 
 ### 1. Load Required Documents
 ✓ Loading reconnaissance assessment and target specifications
 - Read the assessment report from `{{ARG1}}` (check OutputResumes/ or Scoring_Rubrics/ directories)
 - Read the job description from `Job_Postings/{{ARG2}}` (add .md extension if needed)
-- Determine mode: gaps-only if {{ARG3}} == "gaps-only", otherwise full preparation
+- Parse {{ARG3}} to determine:
+  - Mode: gaps-only if {{ARG3}} == "gaps-only", otherwise full preparation
+  - Prep time: parse time value (1d=1 day, 3d=3 days, 1w=1 week, 2w=2 weeks), default 1 week
 
 ### 2. Extract Key Information
 
@@ -69,6 +129,7 @@ Use WebSearch and WebFetch to research:
 - Technical concepts and implementations
 - Certification requirements and preparation materials
 - Real-world application examples
+- **Realistic time-to-competency estimates for each skill**
 
 ### 4. Generate Briefing Note Structure
 ✓ Compiling intelligence brief with training protocol
@@ -77,6 +138,15 @@ Create a comprehensive briefing document with the following sections:
 
 #### A. Executive Summary
 - Overall preparedness assessment
+- **Priority Breakdown**:
+  ```
+  🔴 FOCUS NOW: X topics (estimated Y hours)
+  🟡 IF TIME PERMITS: X topics (estimated Y hours)
+  🟢 SKIM ONLY: X topics (estimated Y hours)
+  Total estimated prep time needed: Z hours
+  Available prep time: [from ARG3 or default]
+  Time sufficiency: [Sufficient / Tight / Insufficient - prioritization critical]
+  ```
 - Critical gaps requiring immediate attention
 - Recommended preparation timeline
 - Key focus areas for interview success
@@ -85,11 +155,79 @@ Create a comprehensive briefing document with the following sections:
 For each gap/requirement, provide:
 - **Current State**: Candidate's current level
 - **Target State**: What the role requires
-- **Gap Severity**: Critical/High/Medium/Low
+- **Gap Severity**: Critical/High/Medium/Low (role importance)
 - **Time to Bridge**: Estimated hours/days needed
+- **Study Priority**: 🔴 FOCUS NOW / 🟡 IF TIME PERMITS / 🟢 SKIM ONLY
+- **Priority Rationale**: Brief explanation of why this priority was assigned
 
-#### C. Detailed Study Guide
-For each topic area:
+Example format:
+```markdown
+##### Kubernetes Orchestration
+- **Current State**: No direct experience; familiar with Docker
+- **Target State**: Production cluster management
+- **Gap Severity**: Critical (core job requirement)
+- **Time to Bridge**: 40+ hours for competency
+- **Study Priority**: 🟢 SKIM ONLY
+- **Priority Rationale**: Despite critical severity, requires more time than available; focus on terminology and concepts, prepare gap acknowledgment strategy
+- **Minimum Viable Prep**: 2 hours (understand key concepts, prepare to discuss learning plan)
+```
+
+```markdown
+##### Python Scripting
+- **Current State**: Basic scripting experience
+- **Target State**: Automation and tooling development
+- **Gap Severity**: Medium (used for automation tasks)
+- **Time to Bridge**: 4-6 hours with existing programming background
+- **Study Priority**: 🔴 FOCUS NOW
+- **Priority Rationale**: Adjacent skills accelerate learning; high ROI for time invested; likely technical screen topic
+- **Minimum Viable Prep**: 3 hours (complete practice exercises, prepare code samples)
+```
+
+#### C. Priority-Based Study Plan
+
+Generate a day-by-day study plan based on available prep time:
+
+**For 1-3 days available:**
+```markdown
+## Priority-Based Study Plan (3 Days Available)
+
+### Day 1: FOCUS NOW Topics (Priority: Maximum Impact)
+- [ ] [Topic 1] (X hrs) - 🔴 FOCUS NOW
+- [ ] [Topic 2] (X hrs) - 🔴 FOCUS NOW
+Daily total: X hours
+
+### Day 2: FOCUS NOW Completion + IF TIME PERMITS
+- [ ] [Topic 3] (X hrs) - 🔴 FOCUS NOW
+- [ ] [Topic 4] (X hrs) - 🟡 IF TIME PERMITS
+Daily total: X hours
+
+### Day 3: Review + SKIM ONLY
+- [ ] Review FOCUS NOW topics (2 hrs)
+- [ ] [Topic 5] terminology review (30 min) - 🟢 SKIM ONLY
+- [ ] [Topic 6] quick overview (30 min) - 🟢 SKIM ONLY
+- [ ] Prepare gap acknowledgment talking points (30 min)
+Daily total: X hours
+```
+
+**For 1-2 weeks available:**
+```markdown
+## Priority-Based Study Plan (1 Week Available)
+
+### Days 1-2: FOCUS NOW Topics (Foundation Building)
+[List topics with time allocations]
+
+### Days 3-4: FOCUS NOW Completion + IF TIME PERMITS
+[List topics with time allocations]
+
+### Days 5-6: IF TIME PERMITS + Practice
+[List topics with time allocations]
+
+### Day 7: Review + SKIM ONLY + Final Prep
+[List review activities and SKIM ONLY topics]
+```
+
+#### D. Detailed Study Guide
+For each topic area (organized by Study Priority - FOCUS NOW topics first):
 
 ##### 1. Core Concepts
 - Fundamental principles and theory
@@ -130,11 +268,12 @@ For each topic area:
   - Books and in-depth resources
   - Mentorship opportunities
 
-#### D. Action Plan
+#### E. Action Plan
 - **24 Hours Before Interview**:
-  - Critical topics to review
+  - Critical topics to review (FOCUS NOW items only)
   - Key talking points to prepare
   - Questions to ask the interviewer
+  - Gap acknowledgment scripts ready
 
 - **3 Days Before Interview**:
   - Hands-on practice priorities
@@ -146,14 +285,31 @@ For each topic area:
   - Projects to complete
   - Skills to demonstrate
 
-#### E. Interview Strategy
-- How to acknowledge gaps professionally
+#### F. Interview Strategy
+
+##### Acknowledging Gaps Professionally
+For each 🟢 SKIM ONLY topic with Critical/High severity, provide a gap acknowledgment script:
+
+```markdown
+**Gap: [Topic Name]**
+**Acknowledgment Script:**
+"While I haven't had direct production experience with [Topic], I understand its importance for this role. I've familiarized myself with [key concepts/terminology]. In my experience with [related technology], I [relevant transferable experience]. I'm committed to ramping up quickly—I've already [specific action taken] and have a learning plan that includes [specific resources/timeline]."
+
+**Key Points to Emphasize:**
+- Awareness of the skill's importance
+- Related/transferable experience
+- Concrete learning plan
+- Quick ramp-up evidence from past experience
+```
+
+##### Additional Interview Strategies
 - Demonstrating learning ability and growth mindset
 - Pivoting to related strengths
 - Using transferable skills effectively
+- Turning gaps into growth narrative
 
-#### F. Quick Reference Guide
-- One-page summary of key concepts
+#### G. Quick Reference Guide
+- One-page summary of key concepts (FOCUS NOW topics)
 - Formula sheet or command reference
 - Common acronyms and terminology
 - Industry-specific metrics and KPIs
@@ -165,6 +321,7 @@ For each topic area:
 - Prioritize critical gaps that could be deal-breakers
 - Provide accelerated learning paths
 - Include mitigation strategies for unchangeable gaps
+- Emphasize gap acknowledgment strategies for SKIM ONLY items
 
 **If full preparation mode:**
 - Cover all job requirements comprehensively
@@ -186,9 +343,9 @@ For each topic area:
 - Format: Markdown with clear headings and sections
 
 **Logical Splitting Guidelines:**
-- Part 1: Executive Summary + Skill Gap Analysis + first topic areas
-- Part 2: Additional topic areas (continue study guides)
-- Part 3: Remaining topics + Action Plan + Interview Strategy + Quick Reference
+- Part 1: Executive Summary + Priority Breakdown + Skill Gap Analysis + Priority-Based Study Plan
+- Part 2: Detailed Study Guides for FOCUS NOW and IF TIME PERMITS topics
+- Part 3: SKIM ONLY study guides + Action Plan + Interview Strategy + Quick Reference
 - Split at natural section boundaries, never mid-topic
 - Each part should include a header referencing total parts (e.g., "Part 1 of 3")
 - Include navigation references at start/end of each part
@@ -197,23 +354,28 @@ For each topic area:
 
 Ensure the briefing note:
 - ✅ Addresses every identified gap or requirement
+- ✅ Assigns Study Priority tag to every topic
+- ✅ Includes Priority Breakdown in Executive Summary
+- ✅ Provides Priority-Based Study Plan with daily schedule
 - ✅ Provides actionable, specific learning resources
 - ✅ Includes realistic timelines for skill development
 - ✅ Offers practical exercises and hands-on practice
 - ✅ Prepares for likely interview scenarios
 - ✅ Balances depth with time constraints
 - ✅ Uses current, relevant industry information
+- ✅ Includes gap acknowledgment scripts for SKIM ONLY critical/high items
 - ✅ **Each individual part does not exceed 25,000 tokens**
 - ✅ **Multi-part reports split logically at section boundaries**
 
 ## Output
 
 The final briefing note should be a comprehensive, actionable study guide that:
-1. Clearly identifies what needs to be learned
-2. Provides structured learning paths
+1. Clearly identifies what needs to be learned with priority tags
+2. Provides time-aware structured learning paths
 3. Includes practical exercises and examples
 4. Prepares for specific interview scenarios
 5. Offers quick-reference materials for last-minute review
+6. Provides professional gap acknowledgment strategies
 
 **MULTI-PART OUTPUT REQUIREMENTS**:
 - Create as many parts as needed to cover all content comprehensively
@@ -221,7 +383,7 @@ The final briefing note should be a comprehensive, actionable study guide that:
 - Split content logically at section boundaries (never mid-topic)
 - Each part should be self-contained enough to be useful independently
 - Include clear navigation between parts (e.g., "Continued in Part 2", "Continued from Part 1")
-- Part 1 should always include the Executive Summary and overview
-- Final part should always include the Action Plan and Quick Reference Guide
+- Part 1 should always include the Executive Summary, Priority Breakdown, and Study Plan
+- Final part should always include the Interview Strategy and Quick Reference Guide
 
-The candidate should be able to use this briefing note as their primary preparation resource for the interview.
+The candidate should be able to use this briefing note as their primary preparation resource for the interview, with clear guidance on where to focus their limited preparation time.

--- a/.claude/commands/interviewprep.md
+++ b/.claude/commands/interviewprep.md
@@ -1,9 +1,9 @@
 ---
 description: Generate customized interview questions based on job description and tailored resume
-argument-hint: <resume-file> <job-description> [number-of-questions]
+argument-hint: <resume-file> <job-description> [number-of-questions] [prep-time]
 ---
 
-You are preparing a candidate for their interview by generating highly relevant interview questions based on the specific job description and their tailored resume that the employer has received.
+You are preparing a candidate for their interview by generating highly relevant interview questions based on the specific job description and their tailored resume that the employer has received. Questions are prioritized by likelihood of being asked to help candidates focus their limited practice time.
 
 ## Your Task
 
@@ -13,22 +13,59 @@ Generate a comprehensive set of interview questions that an employer would likel
 3. Potential gaps or areas requiring clarification
 4. Behavioral competencies relevant to the role
 
+Each question receives a **Question Likelihood** tag to help candidates prioritize their preparation.
+
 ## Arguments
 
 - `{{ARG1}}`: Tailored resume file (required) - The Step 3 final resume sent to employer
 - `{{ARG2}}`: Job description file (required) - The original job posting
 - `{{ARG3}}`: Number of questions (optional) - Defaults to 10 if not specified
+- `{{ARG4}}`: Prep time (optional) - Practice time available: `1d`, `2d`, `3d`, `1w`, `2w`. Defaults to 3 days if not specified
+
+## Question Likelihood Tags
+
+| Tag | Meaning | When to Apply |
+|-----|---------|---------------|
+| 🔴 **HIGH LIKELIHOOD** | Almost certain to be asked | Core job requirements, obvious resume claims to verify, standard behavioral questions for role level |
+| 🟡 **MODERATE LIKELIHOOD** | Likely to come up | Secondary requirements, deeper probes on experience, role-specific scenarios |
+| 🟢 **LOW LIKELIHOOD** | Possible but less common | Nice-to-have skills, edge cases, advanced scenarios |
+
+### Likelihood Assignment Logic
+
+```
+IF (Question addresses must-have job requirement) AND (Directly verifies resume claim):
+    → 🔴 HIGH LIKELIHOOD
+
+IF (Question is standard behavioral for role level) AND (Common in industry):
+    → 🔴 HIGH LIKELIHOOD
+
+IF (Question probes gap between resume and requirements):
+    → 🔴 HIGH LIKELIHOOD
+
+IF (Question addresses preferred/secondary requirement):
+    → 🟡 MODERATE LIKELIHOOD
+
+IF (Question digs deeper into already-verified areas):
+    → 🟡 MODERATE LIKELIHOOD
+
+IF (Question addresses nice-to-have skills):
+    → 🟢 LOW LIKELIHOOD
+
+IF (Question covers edge cases or advanced scenarios):
+    → 🟢 LOW LIKELIHOOD
+```
 
 ## Step-by-Step Process
 
 ### YAML front matter for interview prep output
-Save the question set to `OutputResumes/Interview_Prep_*` with this prefix:
+Save the question set to `Briefing_Notes/Interview_Prep_*` with this prefix:
 
 ```yaml
 ---
 resume_file: {{ARG1}}
 job_file: Job_Postings/{{ARG2}}
 question_count: {{ARG3 or 10}}
+prep_time: "<parsed prep time, e.g., '3 days' or '1 week'>"
 role: <role title>
 company: <company name>
 candidate: <full candidate name>
@@ -36,7 +73,7 @@ generated_by: /interviewprep
 generated_on: <ISO8601 timestamp>
 output_type: interview_prep
 status: draft
-version: 1.0
+version: 1.1
 ---
 ```
 
@@ -46,6 +83,7 @@ Include the block before the first heading and update counts/timestamps on rerun
 - Read the tailored resume from `{{ARG1}}` (check OutputResumes/ directory)
 - Read the job description from `Job_Postings/{{ARG2}}` (add .md extension if needed)
 - Set question count: Use {{ARG3}} if provided, otherwise default to 10
+- Parse prep time: Use {{ARG4}} if provided, otherwise default to 3 days
 
 ### 2. Analyze Resume vs. Job Requirements
 
@@ -80,11 +118,13 @@ For each question, provide:
 - Clear, specific, and relevant to the role
 - Appropriate difficulty level for the position
 - Mix of open-ended and specific formats
+- **Question Likelihood tag** (🔴/🟡/🟢)
 
 #### B. Question Context
 - Why this question is likely to be asked
 - What the interviewer is trying to assess
 - Connection to job requirements or resume claims
+- **Likelihood rationale** - why this probability level
 
 #### C. Suggested Answer Approach
 - Key points to cover in response
@@ -96,6 +136,11 @@ For each question, provide:
 - 2-3 likely follow-up probes
 - How to handle deeper drilling
 - Areas where interviewer might challenge
+
+#### E. Practice Priority
+- **Minimum practice time**: X minutes
+- **Recommended practice time**: Y minutes
+- **Practice method**: Mock answer, written outline, or quick mental review
 
 ### 5. Question Types to Include
 
@@ -133,8 +178,66 @@ If the analysis reveals potential gaps between resume and requirements:
 - Include questions that probe transferable skills
 - Add questions about learning agility and adaptation
 - Include scenario questions to test problem-solving without direct experience
+- Mark gap-probing questions as 🔴 HIGH LIKELIHOOD
 
-### 7. Format and Save
+### 7. Generate Priority-Based Practice Schedule
+
+Based on available prep time, create a practice schedule:
+
+**For 1-2 days available:**
+```markdown
+## Practice Schedule (2 Days Available)
+
+### Day 1: HIGH LIKELIHOOD Questions (4-5 hours)
+- [ ] Q1: [Question summary] (30 min) - 🔴 HIGH LIKELIHOOD
+- [ ] Q2: [Question summary] (30 min) - 🔴 HIGH LIKELIHOOD
+- [ ] Q3: [Question summary] (30 min) - 🔴 HIGH LIKELIHOOD
+- [ ] Mock interview practice with HIGH LIKELIHOOD questions (2 hrs)
+
+### Day 2: MODERATE LIKELIHOOD + Review (3-4 hours)
+- [ ] Q4: [Question summary] (20 min) - 🟡 MODERATE LIKELIHOOD
+- [ ] Q5: [Question summary] (20 min) - 🟡 MODERATE LIKELIHOOD
+- [ ] Review HIGH LIKELIHOOD answers (1 hr)
+- [ ] LOW LIKELIHOOD quick review (30 min) - 🟢 Skim only
+- [ ] Opening/closing statements practice (30 min)
+```
+
+**For 3-5 days available:**
+```markdown
+## Practice Schedule (3 Days Available)
+
+### Day 1: HIGH LIKELIHOOD Deep Practice
+- [ ] All HIGH LIKELIHOOD questions - full STAR answers written
+- [ ] Record and review mock answers
+
+### Day 2: MODERATE LIKELIHOOD + Technical Prep
+- [ ] MODERATE LIKELIHOOD questions - outline key points
+- [ ] Technical demonstration practice
+
+### Day 3: Full Mock Interview + LOW LIKELIHOOD Skim
+- [ ] Complete mock interview (all HIGH + select MODERATE)
+- [ ] Quick review of LOW LIKELIHOOD questions
+- [ ] Prepare questions for interviewer
+```
+
+**For 1-2 weeks available:**
+```markdown
+## Practice Schedule (1 Week Available)
+
+### Days 1-2: HIGH LIKELIHOOD Mastery
+[Detailed schedule]
+
+### Days 3-4: MODERATE LIKELIHOOD Development
+[Detailed schedule]
+
+### Days 5-6: Mock Interviews + Refinement
+[Detailed schedule]
+
+### Day 7: Final Review + LOW LIKELIHOOD Skim
+[Detailed schedule]
+```
+
+### 8. Format and Save
 
 Create a structured interview preparation guide:
 
@@ -145,28 +248,49 @@ Create a structured interview preparation guide:
 ### Executive Summary
 - Total Questions: [Number]
 - Estimated Interview Duration: [Time estimate]
+- **Likelihood Breakdown**:
+  ```
+  🔴 HIGH LIKELIHOOD: X questions (practice time: Y hours)
+  🟡 MODERATE LIKELIHOOD: X questions (practice time: Y hours)
+  🟢 LOW LIKELIHOOD: X questions (practice time: Y minutes)
+  Total recommended practice time: Z hours
+  Available prep time: [from ARG4 or default]
+  ```
 - Key Focus Areas: [Top 3-4 areas]
 - Critical Success Factors: [What will make candidate successful]
 
+### Practice Schedule
+[Generated based on prep time]
+
 ### Question Set
 
-#### Question 1: [Category - e.g., Technical]
+#### Question 1: [Category - e.g., Technical] 🔴 HIGH LIKELIHOOD
 **Question:** [The actual question]
 
-**Context:** [Why this will be asked]
+**Likelihood Rationale:** [Why this is likely to be asked]
+
+**Context:** [What interviewer is assessing]
 
 **Recommended Approach:**
 - [Key point 1]
 - [Key point 2]
 - [Example from resume to reference]
 
+**Practice Priority:**
+- Minimum: X minutes
+- Recommended: Y minutes
+- Method: [Mock answer / Written outline / Mental review]
+
 **Potential Follow-ups:**
 1. [Follow-up question 1]
 2. [Follow-up question 2]
 
+**Red Flags to Avoid:**
+- [What not to say/do]
+
 ---
 
-[Repeat for all questions]
+[Repeat for all questions, organized by likelihood: HIGH first, then MODERATE, then LOW]
 
 ### Quick Reference Sheet
 - Top 3 achievements to emphasize
@@ -186,14 +310,14 @@ Create a structured interview preparation guide:
 - Location: `Briefing_Notes/` directory
 
 **Logical Splitting Guidelines:**
-- Part 1: Executive Summary + Technical questions + first set of behavioral questions
-- Part 2: Additional behavioral questions + experience verification questions
-- Part 3: Remaining questions + Strategic Guidance + Quick Reference Sheet
+- Part 1: Executive Summary + Practice Schedule + HIGH LIKELIHOOD questions
+- Part 2: MODERATE LIKELIHOOD questions
+- Part 3: LOW LIKELIHOOD questions + Strategic Guidance + Quick Reference Sheet
 - Split at natural question boundaries, never mid-question
 - Each part should include a header referencing total parts (e.g., "Part 1 of 3")
 - Include navigation references at start/end of each part
 
-### 8. Include Strategic Guidance
+### 9. Include Strategic Guidance
 
 Add a section with:
 - **Opening Statement**: 60-second pitch tailored to role
@@ -205,11 +329,14 @@ Add a section with:
 
 Ensure the interview questions:
 - ✅ Directly relate to job requirements or resume content
+- ✅ Each question has a Likelihood tag (🔴/🟡/🟢)
+- ✅ Likelihood Breakdown included in Executive Summary
+- ✅ Practice Schedule generated based on prep time
 - ✅ Balance technical and behavioral assessment
 - ✅ Include both strengths-based and gap-probing questions
 - ✅ Provide actionable guidance for responses
 - ✅ Cover all critical competencies for the role
-- ✅ Progress from easier to more challenging
+- ✅ Questions organized by likelihood (HIGH first)
 - ✅ Include scenario-based questions relevant to actual job duties
 - ✅ **Each individual part does not exceed 25,000 tokens**
 - ✅ **Multi-part reports split logically at question boundaries**
@@ -218,10 +345,11 @@ Ensure the interview questions:
 
 The final interview preparation guide should:
 1. Build candidate confidence through thorough preparation
-2. Anticipate likely questions based on specific resume/job alignment
-3. Provide strategic response frameworks
-4. Include recovery strategies for difficult questions
-5. Prepare candidate for various interview formats (phone, video, panel)
+2. **Prioritize practice time on most likely questions**
+3. Anticipate likely questions based on specific resume/job alignment
+4. Provide strategic response frameworks
+5. Include recovery strategies for difficult questions
+6. Prepare candidate for various interview formats (phone, video, panel)
 
 **MULTI-PART OUTPUT REQUIREMENTS**:
 - Create as many parts as needed to cover all questions comprehensively
@@ -229,7 +357,7 @@ The final interview preparation guide should:
 - Split content logically at question boundaries (never mid-question)
 - Each part should be self-contained enough to be useful independently
 - Include clear navigation between parts (e.g., "Continued in Part 2", "Continued from Part 1")
-- Part 1 should always include the Executive Summary and overview
+- Part 1 should always include Executive Summary, Practice Schedule, and HIGH LIKELIHOOD questions
 - Final part should always include Strategic Guidance and Quick Reference Sheet
 
-The candidate should be able to use this guide for focused interview practice and feel prepared for the actual interview conversation.
+The candidate should be able to use this guide for focused interview practice, knowing exactly which questions deserve the most preparation time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,15 +259,22 @@ Located in `.claude/templates/`:
   - Generates comprehensive comparison report with recommendations
   - Supports career planning and negotiation positioning
 
-- `/briefing <assessment-report> <job-description> [gaps-only]`: Creates study guide briefing (Step 5)
+- `/briefing <assessment-report> <job-description> [gaps-only|prep-time]`: Creates study guide briefing (Step 5)
   - Analyzes assessment to identify skill gaps and weaknesses
   - Researches current best practices and learning resources
   - Generates detailed study guide with timelines
+  - **Time-aware Study Priority tags**: 🔴 FOCUS NOW, 🟡 IF TIME PERMITS, 🟢 SKIM ONLY
+  - Accepts prep time: `1d`, `2d`, `3d` (days) or `1w`, `2w` (weeks)
+  - Priority-Based Study Plan with day-by-day schedule
+  - Gap acknowledgment scripts for SKIM ONLY critical items
   - Two modes: gaps-only focus or comprehensive preparation
   - Includes interview questions, hands-on exercises, and quick references
 
-- `/interviewprep <resume-file> <job-description> [number-of-questions]`: Generate interview questions (Step 6)
+- `/interviewprep <resume-file> <job-description> [number-of-questions] [prep-time]`: Generate interview questions (Step 6)
   - Creates likely interview questions based on resume-job alignment
+  - **Question Likelihood tags**: 🔴 HIGH LIKELIHOOD, 🟡 MODERATE LIKELIHOOD, 🟢 LOW LIKELIHOOD
+  - Accepts prep time: `1d`, `2d`, `3d` (days) or `1w`, `2w` (weeks)
+  - Priority-Based Practice Schedule with day-by-day planning
   - Defaults to 10 questions if number not specified
   - Balances technical and behavioral questions
   - Provides answer strategies and STAR format guidance


### PR DESCRIPTION
## Summary

Implements #1: Add prioritization tags that help candidates focus their limited preparation time effectively.

### `/briefing` - Study Priority Tags
- 🔴 **FOCUS NOW** - Study this first
- 🟡 **IF TIME PERMITS** - Secondary priority  
- 🟢 **SKIM ONLY** - Quick review, don't deep-dive

### `/interviewprep` - Question Likelihood Tags
- 🔴 **HIGH LIKELIHOOD** - Almost certain to be asked
- 🟡 **MODERATE LIKELIHOOD** - Likely to come up
- 🟢 **LOW LIKELIHOOD** - Possible but less common

### Common Enhancements
- Optional prep-time parameter (`1d`, `2d`, `3d`, `1w`, `2w`)
- Priority-Based Study/Practice Schedule with daily planning
- Priority breakdown in Executive Summary
- Gap acknowledgment scripts for items that can't be mastered in time

## Key Design Decision

**Study Priority** is distinct from **Gap Severity**:
- Gap Severity = "How important is this skill to the role?"
- Study Priority = "What should I study first given my time?"

This allows a Critical severity gap to receive SKIM ONLY priority when it requires more time to learn than available, with guidance on how to acknowledge the gap professionally.

## Files Changed
- `.claude/commands/briefing.md` - Study Priority system
- `.claude/agents/interview-briefing.md` - Priority assignment logic
- `.claude/commands/interviewprep.md` - Question Likelihood system
- `.claude/agents/interview-question-generator.md` - Likelihood assignment logic
- `CLAUDE.md` - Updated documentation

## Test plan
- [ ] Run `/briefing` with assessment and verify Study Priority tags appear on each topic
- [ ] Run `/briefing` with prep-time parameter (e.g., `3d`) and verify schedule adjusts
- [ ] Run `/interviewprep` and verify Likelihood tags on each question
- [ ] Run `/interviewprep` with prep-time parameter and verify practice schedule
- [ ] Verify Executive Summary includes priority breakdown in both commands
- [ ] Confirm gap acknowledgment scripts appear for SKIM ONLY critical items

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)