### PR TITLE
feat: forward-facing cover letter mode

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Intelligence-driven career management plugins for Claude Code and Codex",
-    "version": "2.12.0"
+    "version": "2.13.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Intelligence-driven career management plugins for Claude Code",
-    "version": "2.12.0"
+    "version": "2.13.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.13.0] - 2026-06-01
+
+### Added
+
+- **Forward-facing cover letter mode (`/jobops:coverletter --mode=forward`, or `preferences.cover_letter_mode: forward`)** — an alternate to the default retrospective letter. Instead of matching the job's requirements to past work, forward mode proposes a **dual-anchored first-90-days plan**: every proposed action sits on a real problem (traceable to a verified primary source or the JD, never speculation) and a concrete past proof point. The `/coverletter` skill runs a mandatory five-question intake interview (primed cheaply from the JD and existing OSINT) before dispatching a new `step4-cover-letter-forward` agent. The agent reuses the retrospective letter's voice discipline, primary-source verification, and independent sub-agent review, and adds a dual-anchor reviewer check that cuts any forward claim lacking a proof anchor or aimed at an unverifiable problem. The table becomes a First-90-Days Plan (problem → action → proof), body paragraphs become "How I'd approach X:", and the close layers a first-90-days throughline with the 6–12 month arc. Retrospective remains the default; configs lacking the new key behave exactly as before.
+
 ## [2.12.0] - 2026-05-31
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ codex plugin list
 - Every skill (except setup) starts with config preamble reading `.jobops/config.json`
 - jobops-ic skills include prerequisite check for jobops plugin
 - Templates bundled in plugin, copied to `.jobops/templates/default/` via setup
+- `step4-cover-letter.md` (retrospective) and `step4-cover-letter-forward.md` (forward) are a paired set. Shared, mode-agnostic rules (contact header, Step 3a primary-source pipeline, voice/style §5a, banned-construction list, Step 6a sub-agent review) are reproduced verbatim in both. Any edit to a shared rule must be applied to BOTH files.
 
 ## Version Management
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="Images/JobOps_logo.png" alt="JobOps Logo" width="400">
 </p>
 
-**Version 2.12.0** | [Changelog](CHANGELOG.md) | [Why I Built This](Why_I_Built_This.md)
+**Version 2.13.0** | [Changelog](CHANGELOG.md) | [Why I Built This](Why_I_Built_This.md)
 
 Two Claude Code and Codex plugins for systematic, intelligence-driven career management — from resume development to independent consulting.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The folder names (`Experience/`, `CareerHighlights/`, `Technology/`) and the fro
 |-------|-------------|
 | `/jobops:buildresume` | Complete 3-step resume process (draft, provenance check, final) |
 | `/jobops:provenance-check` | Standalone credibility analysis on a draft resume |
-| `/jobops:coverletter` | Strategic cover letter with requirements-matching table |
+| `/jobops:coverletter` | Strategic cover letter — retrospective (requirements→proof) or forward mode (`--mode=forward`: dual-anchored first-90-days plan via a short interview), set by `preferences.cover_letter_mode` |
 
 ### Application Tracking
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,6 +29,8 @@ Schema: see `docs/superpowers/specs/2026-04-23-plugin-config-redesign-design.md`
 
 `config.candidate` holds the candidate's header contact fields (`name`, `credentials`, `location`, `phone`, `email`, `linkedin`, `github`), collected in `/jobops:setup` Step 4b. The `buildresume` and `coverletter` flows source the document header from this block so the resume and cover letter render identical contact lines. `phone` is a distinct field joined with ` | ` (or `•` on resumes); empty fields are omitted with their separator and never concatenated onto an adjacent field.
 
+`config.preferences.cover_letter_mode` (`retrospective` | `forward`, default `retrospective`) selects how `/jobops:coverletter` writes the letter. A config written before this key existed has no `cover_letter_mode`; consumers treat the absence as `retrospective`. `/jobops:coverletter --mode=` overrides it per-invocation. `forward` mode runs a mandatory skill-level intake interview and dispatches `step4-cover-letter-forward` instead of `step4-cover-letter`; both agents share voice, provenance, and sub-agent-review rules.
+
 Creation: only by `/jobops:setup`. Extended by `/jobops-ic:setup`. Runtime skills never
 write it, with one narrow exception: `/jobops:dashboard` adds the
 `directories.application_tracker` key (preserving all other keys) if a pre-existing

--- a/docs/superpowers/plans/2026-06-01-forward-facing-cover-letter-mode-verification.md
+++ b/docs/superpowers/plans/2026-06-01-forward-facing-cover-letter-mode-verification.md
@@ -1,0 +1,72 @@
+# Forward Cover-Letter Mode - End-to-End Routing Verification
+
+**Purpose:** Confirm that the four routing scenarios in `plugins/jobops/skills/coverletter/SKILL.md` resolve unambiguously, the forward agent's stop condition guards against mis-wired dispatch, and the dual-anchor guardrail is consistent across the three places it appears in `plugins/jobops/agents/step4-cover-letter-forward.md`.
+
+**Branch:** `feat/forward-cover-letter-mode`
+**Verified on:** 2026-06-01
+
+---
+
+## 1. Routing Scenario Table
+
+| # | Scenario | Expected outcome | Verdict | SKILL.md line(s) that determine it |
+|---|----------|-----------------|---------|-------------------------------------|
+| 1 | No `--mode` flag; `config.preferences.cover_letter_mode: forward` | Forward intake interview runs; `step4-cover-letter-forward` dispatched | PASS | Line 20 (flag absent - fall to config; config = `forward`); line 23 (`forward` branch) |
+| 2 | `--mode=retrospective`; `config.preferences.cover_letter_mode: forward` | No interview; `step4-cover-letter` dispatched (flag wins over config) | PASS | Line 20 (flag present and valid - flag wins); line 22 (`retrospective` branch) |
+| 3 | No `--mode` flag; `cover_letter_mode` key absent from config | No interview; `step4-cover-letter` dispatched (absence defaults to `retrospective`) | PASS | Line 20 ("else `retrospective` (a config written before this key existed has no `cover_letter_mode`; treat the absence as `retrospective`)"); line 22 (`retrospective` branch) |
+| 4 | `--mode=sideways` (invalid value) | Rejected immediately with message: `Invalid --mode value. Use retrospective or forward.` | PASS | Line 20 ("Reject an invalid `--mode=` value with: `Invalid --mode value. Use retrospective or forward.`") |
+
+All four scenarios resolve to exactly one outcome with no ambiguity. The resolution order is explicit and unambiguous: (1) flag if present and valid, (2) config key if present, (3) `retrospective` as the final default. An invalid flag value is rejected before the config is consulted, so the config can never rescue a bad flag value.
+
+---
+
+## 2. Forward Agent Stop Condition (section 1 - Input Validation)
+
+**File:** `plugins/jobops/agents/step4-cover-letter-forward.md`
+
+**Line 25:** "**Forward mode does not run without these.** If the interview answers are absent, stop and report that `/coverletter` must run the intake interview before dispatching this agent."
+
+This stop condition is correctly placed in section 1 (Input Validation), before any drafting work begins. A direct or mis-wired dispatch that omits the intake-interview answers will cause the agent to halt and surface an actionable error - it cannot silently produce an unanchored letter. The stop message directs the user back to the skill entry point (`/coverletter`), which is the only correct way to trigger a forward-mode dispatch.
+
+**Verdict: CONFIRMED.**
+
+---
+
+## 3. Dual-Anchor Guardrail - Three-Place Consistency Check
+
+The "no speculative action / proof-anchor-required" rule must appear and agree in three places. Evidence:
+
+### 3a. Section 3a Step 5 - Anchoring each action to a verified problem or the JD
+
+**Lines 85-87:** "An action whose target **problem** traces to a `verified` primary source (or is stated plainly in the JD) is anchored - it may appear in the table and body. An action whose problem traces to **neither** a verified source nor the JD is **speculation**. Do not ship it."
+
+Rule stated: every proposed action requires an evidenced-problem anchor (verified source or JD). Speculation is dropped or reframed. The second anchor (past proof) is addressed in the table constraint at lines 83-89 where proof cells require a named entity and quantity.
+
+### 3b. Section 4.4 - Construction rules for "How I'd approach X:" paragraphs
+
+**Lines 196-197:** "Future-tense intent is allowed here **only when both anchors are present** (real problem + concrete proof). A future-tense sentence with no proof behind it, or aimed at a problem the research cannot support, is banned (see §5a and the banned list)."
+
+Rule stated: both anchors required - real evidenced problem AND concrete past proof. Either anchor absent = banned. This is the explicit dual-anchor statement that names both conditions.
+
+### 3c. Section 6a - Reviewer dual-anchor CUT checks
+
+**Lines 481-482:** "**Forward claims missing a proof anchor** - any 'what I'd do' sentence with no named, quantified past artifact behind it. CUT." and "**Forward claims aimed at an unverifiable problem** - any proposed action whose target problem is not traceable to a verified primary source (per the `primary_sources` ledger) or the JD. CUT."
+
+Rule stated: reviewer independently enforces both anchor conditions at the sentence level. Each anchor failure is its own CUT category.
+
+### Consistency assessment
+
+All three placements are mutually consistent:
+- 3a enforces the evidenced-problem anchor at the drafting stage (before the table and body paragraphs are written).
+- 4.4 enforces both anchors simultaneously during paragraph construction.
+- 6a enforces each anchor independently at review, catching any drafting-stage miss before output is written to disk.
+
+No contradictions. The three checks form a layered defence: draft-time anchor binding (3a), construction rule (4.4), and independent sentence-level review (6a).
+
+**Verdict: CONFIRMED - three placements present and mutually consistent.**
+
+---
+
+## 4. Overall Verdict
+
+**PASS.** All four routing scenarios resolve unambiguously. The stop condition guards correctly. The dual-anchor guardrail is present and consistent across all three enforcement points. No ambiguities, contradictions, or silent failure paths found.

--- a/docs/superpowers/plans/2026-06-01-forward-facing-cover-letter-mode.md
+++ b/docs/superpowers/plans/2026-06-01-forward-facing-cover-letter-mode.md
@@ -1,0 +1,720 @@
+# Forward-Facing Cover Letter Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a config-selectable forward-facing cover letter mode in which the candidate proposes a dual-anchored first-90-days plan (real evidenced problem + past proof point), gathered through a mandatory skill-level interview.
+
+**Architecture:** A new self-contained `step4-cover-letter-forward.md` agent sits beside the existing retrospective agent. The `/coverletter` skill resolves an effective mode (`--mode=` flag > `config.preferences.cover_letter_mode` > `retrospective`), runs a structured intake interview for forward mode, and routes to the matching agent. `/jobops:setup` gains a preference question and schema key.
+
+**Tech Stack:** Markdown agent/skill prompt files; JSON config (`.jobops/config.json`); validation via `claude plugin validate plugins/jobops` and `npm test` (Codex compatibility contract). No runtime code or unit-test harness — verification is structural validation plus targeted content (grep) checks and manual functional review.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-forward-facing-cover-letter-mode-design.md`
+
+**Note on "tests" in this plan:** these are prompt/config files, not executable code. Each task's verification uses the repo's real validators (`claude plugin validate`, `npm test`) plus `grep` presence/consistency checks that assert the required content exists. There is no unit-test framework to add; do not invent one.
+
+**Cross-file rule-drift warning:** `step4-cover-letter-forward.md` reproduces shared, mode-agnostic rules from `step4-cover-letter.md` verbatim (contact header, Step 3a pipeline, voice/style, banned list, Step 6a review). Any future edit to a shared rule must be applied to BOTH files. Task 6 adds a contributor note recording this.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `plugins/jobops/skills/setup/SKILL.md` | Preference interview + config schema | Modify (Step 4 question, Step 6 schema) |
+| `plugins/jobops/agents/step4-cover-letter-forward.md` | Forward-mode drafting agent | Create (copy retrospective agent, apply diffs) |
+| `plugins/jobops/skills/coverletter/SKILL.md` | Mode resolution, interview, agent routing | Modify |
+| `docs/ARCHITECTURE.md` | Config contract documentation | Modify |
+| `README.md` | User-facing feature mention | Modify |
+| `CHANGELOG.md` | Release notes | Modify |
+| Version files (×7) | Version bump 2.12.0 → 2.13.0 | Modify (via version-bump skill) |
+| `CLAUDE.md` | Contributor note on the two-agent pairing | Modify |
+
+Implementation order: config (Task 1) → forward agent (Tasks 2–3) → skill routing (Task 4) → validation (Task 5) → docs + contributor note (Task 6) → version + changelog (Task 7).
+
+---
+
+## Task 1: Add `cover_letter_mode` preference to setup
+
+**Files:**
+- Modify: `plugins/jobops/skills/setup/SKILL.md` (Step 4 interview, ~lines 72–84; Step 6 schema, ~lines 154–157)
+
+- [ ] **Step 1: Add the third preference question to Step 4**
+
+In `plugins/jobops/skills/setup/SKILL.md`, locate the Step 4 question list that currently ends with the "Default jurisdiction" item (around line 78–80). After that item and before the `Do **not** ask for default_currency` note, insert:
+
+```markdown
+3. **Cover letter mode** — enum `retrospective` | `forward`. Default `retrospective`.
+   Controls how `/jobops:coverletter` writes the letter. `retrospective` matches the
+   job's requirements to what the candidate has already done. `forward` proposes a
+   dual-anchored first-90-days plan (each action sits on a real, research-evidenced
+   problem and a past proof point) and runs a short intake interview every time it is
+   used. The mode can be overridden per-invocation with `/jobops:coverletter --mode=`.
+```
+
+- [ ] **Step 2: Add the key to the Step 6 config schema**
+
+In the same file, in the `"preferences"` block of the Step 6 JSON schema (currently lines 154–157), add the third key so the block reads:
+
+```json
+  "preferences": {
+    "cultural_profile": "<step-4 value>",
+    "default_jurisdiction": "<step-4 value>",
+    "cover_letter_mode": "<step-4 value, default retrospective>"
+  },
+```
+
+- [ ] **Step 3: Verify the content is present and the JSON block is well-formed**
+
+Run:
+```bash
+cd /home/reggiechan/JobOps
+grep -n 'Cover letter mode' plugins/jobops/skills/setup/SKILL.md
+grep -n 'cover_letter_mode' plugins/jobops/skills/setup/SKILL.md
+```
+Expected: the question line matches once, `cover_letter_mode` matches twice (question prose + schema). Confirm the schema block still has matched braces and the new line ends with a comma only if a key follows it (it is the last key in `preferences`, so it must NOT have a trailing comma — verify the preceding `default_jurisdiction` line now ends with a comma and the new line does not).
+
+- [ ] **Step 4: Validate plugin structure unaffected**
+
+Run:
+```bash
+cd /home/reggiechan/JobOps && claude plugin validate plugins/jobops
+```
+Expected: validation passes (no schema/frontmatter errors).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/reggiechan/JobOps
+git add plugins/jobops/skills/setup/SKILL.md
+git commit -m "feat(setup): add cover_letter_mode preference (retrospective|forward)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Create the forward agent file from the retrospective base
+
+This task creates the new agent file as an exact copy of the retrospective agent, so the shared rules are reproduced verbatim. Task 3 then applies the forward-specific diffs. Splitting it this way keeps each diff reviewable.
+
+**Files:**
+- Create: `plugins/jobops/agents/step4-cover-letter-forward.md` (from `plugins/jobops/agents/step4-cover-letter.md`)
+
+- [ ] **Step 1: Copy the retrospective agent to the new filename**
+
+```bash
+cd /home/reggiechan/JobOps
+cp plugins/jobops/agents/step4-cover-letter.md plugins/jobops/agents/step4-cover-letter-forward.md
+```
+
+- [ ] **Step 2: Update the frontmatter `name` and `description`**
+
+In `plugins/jobops/agents/step4-cover-letter-forward.md`, change the frontmatter (lines 1–11). Replace:
+
+```yaml
+name: step4-cover-letter
+description: Creates a compelling cover letter with requirements-matching table based on the final Step 3 resume
+```
+
+with:
+
+```yaml
+name: step4-cover-letter-forward
+description: Creates a forward-facing cover letter proposing a dual-anchored first-90-days plan (evidenced problem + past proof) based on the final Step 3 resume and a skill-level intake interview
+```
+
+Leave the `tools:` list unchanged.
+
+- [ ] **Step 3: Verify the copy and frontmatter**
+
+Run:
+```bash
+cd /home/reggiechan/JobOps
+grep -n 'name: step4-cover-letter-forward' plugins/jobops/agents/step4-cover-letter-forward.md
+grep -c 'name: step4-cover-letter$' plugins/jobops/agents/step4-cover-letter-forward.md
+```
+Expected: the forward `name:` matches once; the bare retrospective `name: step4-cover-letter` (no `-forward`) matches 0 times (confirms the frontmatter name was changed, not left as the retrospective one).
+
+- [ ] **Step 4: Validate plugin structure**
+
+Run:
+```bash
+cd /home/reggiechan/JobOps && claude plugin validate plugins/jobops
+```
+Expected: passes (the new agent is discovered, frontmatter valid).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/reggiechan/JobOps
+git add plugins/jobops/agents/step4-cover-letter-forward.md
+git commit -m "feat(agent): scaffold step4-cover-letter-forward from retrospective base
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Apply forward-mode diffs to the new agent
+
+All edits are in `plugins/jobops/agents/step4-cover-letter-forward.md`. Apply each step's exact replacement.
+
+**Files:**
+- Modify: `plugins/jobops/agents/step4-cover-letter-forward.md`
+
+- [ ] **Step 1: Rewrite the Overview to describe forward mode**
+
+Replace the `## Overview` paragraph:
+
+```markdown
+## Overview
+I create compelling, tailored cover letters based on the final Step 3 resume, featuring a strategic requirements-matching table that directly maps job requirements to your proven experience.
+```
+
+with:
+
+```markdown
+## Overview
+I create forward-facing cover letters based on the final Step 3 resume and a structured intake interview supplied by the `/coverletter` skill. Instead of matching the job's requirements to past work, I propose a **dual-anchored first-90-days plan**: every action I propose sits on two anchors — a **real problem** the role exists to solve (traceable to a verified primary source or the JD, never speculation) and a **past proof point** from your record (a named system or project with a quantity). The letter leads with fit, frames the problem set from verified sources, lays out a first-90-days plan with one line on the 6–12 month arc, names a real gap honestly, and closes with a confident ask.
+```
+
+- [ ] **Step 2: Add the interview-input contract to Input Validation (§1)**
+
+Replace the `### 1. Input Validation` block:
+
+```markdown
+### 1. Input Validation
+First, I'll verify that I have:
+- The final Step 3 resume (hardened and verified)
+- The original job description
+- Company and role details for personalization
+```
+
+with:
+
+```markdown
+### 1. Input Validation
+First, I'll verify that I have:
+- The final Step 3 resume (hardened and verified)
+- The original job description
+- Company and role details for personalization
+- **The forward intake interview answers** passed by the `/coverletter` skill: (1) the role thesis / problem set, (2) the candidate's first-90-days actions plus a line on the 6–12 month arc, (3) the past proof backing each action, (4) the real gap and how the candidate would work with it, (5) any company-specific notes. **Forward mode does not run without these.** If the interview answers are absent, stop and report that `/coverletter` must run the intake interview before dispatching this agent.
+```
+
+- [ ] **Step 3: Add the problem-anchoring contract to the Step 3a pipeline (§3a, Step 4 — "Decide context mode")**
+
+In the `**Step 4 — Decide context mode**` block of §3a, after the existing two bullets (`≥ 2 verified sources` and `< 2 verified sources`), append:
+
+```markdown
+
+**Step 5 — Anchor the forward plan to verified problems (forward mode only)**
+
+The interview gave the candidate's read on the problem set, primed only from the JD and existing OSINT files. Now bind each proposed first-90-days action to evidence:
+
+- An action whose target **problem** traces to a `verified` primary source (or is stated plainly in the JD) is anchored — it may appear in the table and body.
+- An action whose problem traces to **neither** a verified source nor the JD is **speculation**. Do not ship it. Either reframe the action against a JD-stated requirement, or drop it.
+- Record any dropped/reframed action in the closing notes to the user, naming which interview input was set aside and why (so the candidate can supply evidence and re-run).
+
+With `< 2 verified sources`, forward actions may only anchor their problem to the JD itself; keep them conservative and JD-scoped rather than citing a market situation the research could not confirm.
+```
+
+- [ ] **Step 4: Convert the Requirements Alignment table (§4.3) to the First-90-Days Plan table**
+
+Replace the entire `#### 4.3 Requirements Alignment table (mandatory)` section (heading, constraints, and the sample table) with:
+
+```markdown
+#### 4.3 First-90-Days Plan table (mandatory)
+
+A three-column table that is the scannable core of the forward letter. Each row binds a **real problem** to the **action** the candidate would take in the first 90 days and the **proof** that the candidate can do it. The table is mandatory.
+
+**Constraints:**
+- **Cap at 5 rows.** Six or more becomes a wall.
+- **Every problem cell must trace** to a verified primary source or the JD (no speculation; see §3a Step 5).
+- **Every proof cell must contain a named entity** (project, deal, system, agency, counterparty) and at least one quantity.
+- **Vary row construction.** Do not let every action read `verb + object`; lead some rows with the problem or the constraint.
+- **No dead verbs** (see banned-construction list).
+
+| **The problem (evidenced)** | **What I'd do in the first 90 days** | **Why I can (proof)** |
+|------------------------------|--------------------------------------|------------------------|
+| [Problem 1 — traceable to a verified source or the JD] | [Concrete first-90-days action scoped to that problem] | [Named system/project + quantity from the Step 3 resume] |
+| [Lead with the constraint: the binding limit the role exists to resolve] | [Action that resolves it] | [Named proof + quantity] |
+| [Problem 3] | [Action] | [Named proof + quantity] |
+| [Problem 4] | [Action] | [Named proof + quantity] |
+| [Problem 5] | [Action] | [Named proof + quantity] |
+```
+
+- [ ] **Step 5: Convert the "On X:" paragraphs (§4.4) to "How I'd approach X:" paragraphs**
+
+Replace the entire `#### 4.4 "On X:" evidence paragraphs (2–3 paragraphs)` section with:
+
+```markdown
+#### 4.4 "How I'd approach X:" paragraphs (2–3 paragraphs)
+
+Each body paragraph opens with one of the role's key demands as a colon-led header phrase, then carries the **dual anchor**: the real problem, the intended first-90-days action, and the proof. Examples of openers:
+- "How I'd approach POC-to-production: …"
+- "How I'd approach the workshop side: …"
+- "How I'd approach lease restructuring under board oversight: …"
+
+**Construction rules — each paragraph has three moves, in order:**
+1. **Name the real problem** the demand represents, traceable to a verified source or the JD (not invented). One sentence.
+2. **State the intended action** the candidate would take in the first 90 days, scoped to that problem.
+3. **Ground it in one concrete past artifact**: a named system/project/program (with timeframe) and at least one quantity (users, dollars, headcount, percentage, term length, commits, adoption rate).
+
+Rules:
+- **One paragraph = one problem = one action = one proof.** Not a list of three.
+- Future-tense intent is allowed here **only when both anchors are present** (real problem + concrete proof). A future-tense sentence with no proof behind it, or aimed at a problem the research cannot support, is banned (see §5a and the banned list).
+- Do not paraphrase resume bullets. The proof adds what the bullet cannot: the constraint, the trade-off, the through-line to the action.
+- Each paragraph must connect to a problem named in the context paragraph (4.2) or the JD. If it cannot connect to evidence, cut it.
+```
+
+- [ ] **Step 6: Convert the close (§4.6) to the layered horizon**
+
+Replace the entire `#### 4.6 Forward-looking close (3–4 lines)` section with:
+
+```markdown
+#### 4.6 Layered-horizon close (3–4 lines)
+
+Close on the plan's horizon, layered:
+1. One sentence on the **first-90-days throughline** — the single thing the candidate's early actions add up to.
+2. One sentence on the **6–12 month arc** — where that early work leads, tied to the role's near-term mandate.
+3. A confident, specific **ask**. Not a hope, not a thank-you, not a contact-info restatement. Example: "I would like to be inside the room when those decisions are made."
+
+**Banned in the close:**
+- "Thank you for your consideration"
+- "I look forward to hearing from you"
+- "I would welcome the opportunity to discuss"
+- "Please feel free to contact me"
+- Any restatement of contact info that already appears in the header
+```
+
+- [ ] **Step 7: Narrow the future-tense rule in Voice (§5a)**
+
+In `### 5a. Voice and Style`, under `**Voice:**`, replace the bullet:
+
+```markdown
+- **Declarative, first-person, confident.** No future-tense self-promises. No hedge framing.
+```
+
+with:
+
+```markdown
+- **Declarative, first-person, confident.** No hedge framing. Future-tense intent is the point of this mode, but it is allowed **only when dual-anchored**: the action must address a real problem (traceable to a verified source or the JD) AND rest on a concrete past proof point. Generic or ungrounded future promises ("I would bring my passion," "I would contribute my dedication," any value-proposition claim with nothing behind it) remain banned, as does any action aimed at a problem the research cannot support.
+```
+
+- [ ] **Step 8: Update the banned-constructions list for forward mode**
+
+In the `### Banned Constructions` section, under `**Banned phrases:**`, replace the line:
+
+```markdown
+- "I would bring," "I would contribute," "I would welcome" (any future-tense self-promise)
+```
+
+with:
+
+```markdown
+- "I would bring," "I would contribute," "I would welcome" — **only when ungrounded.** In this forward mode a future-tense statement is permitted when it is dual-anchored (real evidenced problem + concrete past proof). A future-tense statement with no proof anchor, or aimed at a problem the research cannot support, is banned.
+- Speculative actions: any proposed action whose target problem is not traceable to a verified primary source or the JD.
+```
+
+Leave the `"is learnable in [timeframe]"` / gap-trivializing ban exactly as is — it stays in force.
+
+- [ ] **Step 9: Replace the §4.4 reference in the honest-limitation note about future tense**
+
+In `#### 4.4` we removed the "No future-tense promises" line by rewriting the section, but the honest-limitation section (§4.5) is unchanged and still correct. No edit needed in §4.5. Confirm §4.5 still reads "What I do not bring is X. What I do bring is rarer: Y." and still bans trivializing the gap.
+
+Run:
+```bash
+cd /home/reggiechan/JobOps
+grep -n 'What I do not bring is X' plugins/jobops/agents/step4-cover-letter-forward.md
+grep -n 'is learnable in' plugins/jobops/agents/step4-cover-letter-forward.md
+```
+Expected: both match (honest-limitation move intact; gap-trivializing ban intact).
+
+- [ ] **Step 10: Add the dual-anchor check to the Step 6a sub-agent review**
+
+In `### 6a. Sub-Agent Sentence Review`, under `**What the reviewer is specifically hunting for:**`, append two bullets:
+
+```markdown
+- **Forward claims missing a proof anchor** — any "what I'd do" sentence with no named, quantified past artifact behind it. CUT.
+- **Forward claims aimed at an unverifiable problem** — any proposed action whose target problem is not traceable to a verified primary source (per the `primary_sources` ledger) or the JD. CUT.
+```
+
+- [ ] **Step 11: Replace the gold-standard exemplar (§5b) with a forward exemplar**
+
+Replace the prose letter inside `### 5b. Gold-Standard Exemplar` (the block-quoted John Smith letter, from `> John Smith, CFA, FRICS` through `> John Smith, CFA, FRICS` at the signature) with the forward exemplar below. Keep the surrounding framing sentences but update them to describe forward structure:
+
+```markdown
+> John Smith, CFA, FRICS
+> Toronto, ON | (555) 555-0123 | john.smith@example.com | LinkedIn: /in/johnsmith | GitHub: /johnsmith
+>
+> May 28, 2026
+>
+> ABC Inc.
+>
+> Dear John:
+>
+> I'm applying for the Associate Director, Customer Success and Innovation role. I have spent my career taking technical requirements all the way to running software that non-technical colleagues actually use: internal-facing systems, plain-language query tools, and the workshops that turn leaders into hands-on operators. Enterprise AI governance at this scale is new to me; the translation work between business demand and delivery is not.
+>
+> By design, ABC Inc. has front-loaded the hard parts. The demand, the governance, and the delivery capacity already exist, and oversight of AI now sits at the Board-committee level against a policy that draws a hard line between Custom and Public AI. What does not arrive with capacity is translation. The binding constraint is no longer capability but the customer-facing function inside the technology group that turns business-unit demand into governed, delivered tools. That is this role.
+>
+> [First-90-Days Plan table: each row is problem → first-90-days action → proof. E.g. "Internal AI requests stall at proof-of-concept (no owned path to production)" → "Stand up a triage-to-production lane and move two POCs to live tools in the first quarter" → "relationship-intelligence system, 3,000+ commits, plain-language queries colleagues run daily"; "Build-vs-buy decisions lack a Custom-versus-Public test" → "Publish a one-page decision rule mapped to the AI Governance Policy" → "enterprise SaaS rollout, 90% adoption month 1".]
+>
+> How I'd approach POC-to-production: the problem the policy creates is that internal AI requests stall between a working demo and a governed, production tool, because no one owns the path between them. In the first 90 days I would stand up a single triage-to-production lane and move two live requests through it end to end. I can do this because I have already built the kind of system this role describes: my relationship-intelligence system (3,000+ commits) lets a non-technical user query a database in plain language and get structured answers back, the same pattern ABC Inc. would use to seat AI beside a property asset manager. I take ideas to working software people use, not slideware, which is exactly where most internal AI programs stall.
+>
+> How I'd approach the workshop side: the gap once tools exist is adoption, and the JD names enablement as core to the function. In the first quarter I would run a builder workshop for one business unit and convert its analysts from prompt-readers into agent-builders. At JKL Corp. (2022 to 2024) I designed and delivered an AI-powered onboarding program (600+ pages of content and twenty fifteen-minute audio episodes, built in two months) that cut new-hire ramp-up by 50%. The methodology is portable. The same architecture runs against ABC Inc. teams inside their own domains.
+>
+> What I do not bring is enterprise-scale data-warehouse experience; I own the specification, schema, and query architecture, and pair-program the build with Claude Code and Codex. What I do bring is rarer: institutional CRE fluency at platform depth, plus a track record of taking requirements all the way to running systems. That is the exact intersection where the AI Governance Policy now needs translating into customer-facing work.
+>
+> The first 90 days are about proving the triage-to-production lane on two real requests; the first year is about making it the default way the technology group turns business demand into governed tools. I would like to be inside the room when those decisions are made.
+>
+> Sincerely,
+> [signature image]
+> John Smith, CFA, FRICS
+```
+
+Then, immediately after the exemplar, replace the `**What this exemplar does that the model must imitate:**` bullet list so the forward-specific bullets are accurate. Update at minimum these three bullets:
+
+```markdown
+- **First-90-Days Plan table (4.3):** three columns — problem (evidenced) → first-90-days action → proof. Every problem traces to a verified source or the JD; every proof cell has a named system and a quantity.
+- **"How I'd approach X:" paragraphs (4.4):** each carries the dual anchor in order — name the real problem, state the first-90-days action, ground it in one named, quantified past artifact. Future tense is earned by the proof, never floated alone.
+- **Layered-horizon close (4.6):** first-90-days throughline, then the 6–12 month arc ("the first year is about…"), then the confident specific ask. No thank-you, no "look forward to," no contact restatement.
+```
+
+- [ ] **Step 12: Update the Step 6 quality checks and regression self-check for the forward structure**
+
+In `### 6. Quality Checks` and the `#### Regression self-check`, update the structure and table checklist items to match the forward elements. Specifically replace the structure checklist item:
+
+```markdown
+- ✓ **Structure (4.0–4.7):** contact header → fit-led opening → context and role reframe → Requirements Alignment table → "On X:" evidence paragraphs (2–3) → honest-limitation paragraph → forward-looking close → signature with post-nominals. All elements present in order.
+```
+
+with:
+
+```markdown
+- ✓ **Structure (4.0–4.7):** contact header → fit-led opening → context and role reframe → First-90-Days Plan table → "How I'd approach X:" paragraphs (2–3) → honest-limitation paragraph → layered-horizon close → signature with post-nominals. All elements present in order.
+```
+
+And replace the Requirements-table checklist item:
+
+```markdown
+- ✓ **Requirements Alignment table:** no more than 5 rows; row construction varies; every evidence cell has a named entity and at least one quantity.
+```
+
+with:
+
+```markdown
+- ✓ **First-90-Days Plan table:** no more than 5 rows; row construction varies; every problem cell traces to a verified source or the JD; every proof cell has a named entity and at least one quantity.
+```
+
+And replace the "On X:" checklist item:
+
+```markdown
+- ✓ **Each "On X:" paragraph** opens with a colon-led role-demand phrase, carries exactly one artifact with a named system/project and at least one quantity, ties to the context paragraph's binding constraint, and does not paraphrase a resume bullet.
+```
+
+with:
+
+```markdown
+- ✓ **Each "How I'd approach X:" paragraph** carries the dual anchor in order: real problem (evidenced) → first-90-days action → one named, quantified past artifact. No forward claim lacks a proof anchor; no action targets a problem the research cannot support.
+```
+
+And replace the forward-looking-close checklist item:
+
+```markdown
+- ✓ **Forward-looking close** names a specific near-term phase of the firm's work and ends with a confident specific ask. No "thank you for your consideration," no "I look forward to hearing from you," no contact-info restatement.
+```
+
+with:
+
+```markdown
+- ✓ **Layered-horizon close** shows the first-90-days throughline, then one line on the 6–12 month arc, then a confident specific ask. No "thank you for your consideration," no "I look forward to hearing from you," no contact-info restatement.
+```
+
+- [ ] **Step 13: Verify all forward content is present and retrospective artifacts are gone**
+
+Run:
+```bash
+cd /home/reggiechan/JobOps
+F=plugins/jobops/agents/step4-cover-letter-forward.md
+echo "--- present (each should be >=1) ---"
+grep -c 'First-90-Days Plan' $F
+grep -c "How I'd approach" $F
+grep -c 'Layered-horizon close' $F
+grep -c 'dual-anchor' $F
+grep -c 'first 90 days' $F
+echo "--- removed (each should be 0) ---"
+grep -c 'Requirements Alignment table (mandatory)' $F
+grep -c '"On X:" evidence paragraphs' $F
+grep -c 'No future-tense self-promises' $F
+```
+Expected: every "present" count ≥ 1; every "removed" count = 0.
+
+- [ ] **Step 14: Validate plugin structure**
+
+Run:
+```bash
+cd /home/reggiechan/JobOps && claude plugin validate plugins/jobops && npm test
+```
+Expected: both pass.
+
+- [ ] **Step 15: Commit**
+
+```bash
+cd /home/reggiechan/JobOps
+git add plugins/jobops/agents/step4-cover-letter-forward.md
+git commit -m "feat(agent): forward-mode structure, dual-anchor rules, and exemplar
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Mode resolution, interview, and routing in `/coverletter`
+
+**Files:**
+- Modify: `plugins/jobops/skills/coverletter/SKILL.md` (Arguments ~lines 46–49, Configuration ~lines 7–17, Step 3 dispatch ~lines 71–96)
+
+- [ ] **Step 1: Document the `--mode` argument**
+
+In `plugins/jobops/skills/coverletter/SKILL.md`, in the `## Arguments` section, after the `$3` line, add:
+
+```markdown
+- `--mode=retrospective|forward` (optional): overrides `config.preferences.cover_letter_mode` for this invocation. Invalid values are rejected with a message listing the two valid values; the skill does not silently fall back.
+```
+
+- [ ] **Step 2: Add a mode-resolution + interview section before the dispatch step**
+
+In the `## Configuration` section, after the existing `Use config.preferences.cultural_profile …` lines, add:
+
+```markdown
+
+### Cover letter mode
+
+Resolve the **effective mode**: the `--mode=` flag if present and valid, else `config.preferences.cover_letter_mode`, else `retrospective` (a config written before this key existed has no `cover_letter_mode`; treat the absence as `retrospective`). Reject an invalid `--mode=` value with: `Invalid --mode value. Use retrospective or forward.`
+
+- **retrospective** → dispatch the `step4-cover-letter` agent (Step 3 below), unchanged.
+- **forward** → run the forward intake interview, then dispatch the `step4-cover-letter-forward` agent.
+
+#### Forward intake interview (mandatory for forward mode)
+
+Forward mode never drafts without this interview, because the agent runs non-interactively and cannot ask the candidate anything mid-run. Before dispatch:
+
+1. **Prime the problem set cheaply.** Read the JD ($2) and, if it exists, the specialist files under `{config.directories.company_intelligence}/{Company}/` (`corporate.md`, `legal.md`, `leadership.md`, `market.md`). Do not run web searches here — the agent's Step 3a pipeline does the deep verification. Summarize the candidate-facing problem set in 2–4 bullets so the candidate reacts to evidence rather than inventing problems.
+2. **Ask the five questions, one at a time**, in the main conversation:
+   1. **Role thesis / problem set** — given the primed bullets, what is this role actually there to solve?
+   2. **First-90-days actions** — the 2–3 things you'd do first to address that problem set, plus one line on the 6–12 month arc.
+   3. **Per-action proof** — for each action, the past work that backs your ability to do it.
+   4. **Gap & plan** — the real gap you carry and how you'd work with it (without trivializing it as quickly closeable).
+   5. **Company-specific notes** — anything about the firm's situation to reflect in the context paragraph or problem set.
+3. **If the candidate declines or abandons the interview, do not draft.** Tell them forward mode requires the interview, and that retrospective mode (`--mode=retrospective`) produces a letter without one.
+4. **Pass the answers and the primed problem set inline** to the `step4-cover-letter-forward` agent in its dispatch prompt.
+```
+
+- [ ] **Step 3: Make the Step 3 dispatch conditional on mode**
+
+In `## Step 3: Generating Cover Letter`, replace the paragraph that begins `I'm launching the \`step4-cover-letter\` agent …` with:
+
+```markdown
+I dispatch the agent that matches the effective mode resolved in Configuration:
+
+- **retrospective** → the `step4-cover-letter` agent: a contact header followed by seven body elements (fit-led opening, context/role reframe, Requirements Alignment table, "On X:" evidence paragraphs, honest-limitation, forward-looking close, signature), every claim traced to the Step 3 resume and verified primary sources.
+- **forward** → the `step4-cover-letter-forward` agent, with the intake-interview answers and primed problem set passed in. It proposes a **dual-anchored first-90-days plan**: a First-90-Days Plan table (problem → action → proof) and "How I'd approach X:" paragraphs, where every proposed action sits on a real evidenced problem and a concrete past proof point. The fit-led opening, context paragraph, honest-limitation, voice discipline, primary-source verification, and Step 6a sub-agent review are shared with retrospective mode.
+```
+
+- [ ] **Step 4: Verify content present and consistent**
+
+Run:
+```bash
+cd /home/reggiechan/JobOps
+F=plugins/jobops/skills/coverletter/SKILL.md
+grep -c -- '--mode=' $F
+grep -c 'effective mode' $F
+grep -c 'Forward intake interview' $F
+grep -c 'step4-cover-letter-forward' $F
+grep -c 'step4-cover-letter\b' $F
+```
+Expected: `--mode=` ≥ 2, `effective mode` ≥ 1, `Forward intake interview` ≥ 1, `step4-cover-letter-forward` ≥ 2, retrospective agent name still referenced ≥ 1.
+
+- [ ] **Step 5: Validate**
+
+Run:
+```bash
+cd /home/reggiechan/JobOps && claude plugin validate plugins/jobops && npm test
+```
+Expected: both pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/reggiechan/JobOps
+git add plugins/jobops/skills/coverletter/SKILL.md
+git commit -m "feat(coverletter): resolve mode, run forward interview, route to agent
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: End-to-end functional verification (manual)
+
+No automated harness exercises the prompt logic, so verify the three routing paths by reading the resolved instructions and confirming they are unambiguous. This task produces a short verification note, not code.
+
+**Files:**
+- (none modified; verification only)
+
+- [ ] **Step 1: Trace the three mode paths against the skill text**
+
+Read `plugins/jobops/skills/coverletter/SKILL.md` and confirm, for each scenario, exactly one path is determined with no ambiguity:
+1. **No `--mode`, config `cover_letter_mode: forward`** → interview runs, `step4-cover-letter-forward` dispatched.
+2. **`--mode=retrospective`, config `cover_letter_mode: forward`** → no interview, `step4-cover-letter` dispatched (flag wins).
+3. **No `--mode`, config has no `cover_letter_mode` key** → no interview, `step4-cover-letter` dispatched (absence → retrospective).
+4. **`--mode=sideways`** → rejected with the invalid-value message.
+
+- [ ] **Step 2: Confirm the forward agent's stop condition for a missing interview**
+
+Read `plugins/jobops/agents/step4-cover-letter-forward.md` §1 and confirm it halts and reports when interview answers are absent, so a direct/mis-wired dispatch cannot silently produce an unanchored letter.
+
+- [ ] **Step 3: Confirm the dual-anchor guardrail is enforced in three places**
+
+Confirm the "no speculative action / proof-anchor-required" rule appears in: §3a Step 5 (anchoring), §4.4 (construction rules), and §6a (reviewer check). All three must agree.
+
+- [ ] **Step 4: Record the verification note and commit**
+
+Append a dated note to the spec's "Testing" expectations or create `docs/superpowers/plans/2026-06-01-forward-facing-cover-letter-mode-verification.md` with the four traced paths and their outcomes. Then:
+
+```bash
+cd /home/reggiechan/JobOps
+git add docs/superpowers/plans/2026-06-01-forward-facing-cover-letter-mode-verification.md
+git commit -m "docs: forward cover-letter mode routing verification note
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Documentation and contributor note
+
+**Files:**
+- Modify: `docs/ARCHITECTURE.md` (§2 Config file, ~line 30)
+- Modify: `README.md` (cover letter row, ~line 89)
+- Modify: `CLAUDE.md` (Coding Style or a new note)
+
+- [ ] **Step 1: Document the config key in ARCHITECTURE.md**
+
+In `docs/ARCHITECTURE.md` §2 "Config file", after the `config.candidate` paragraph (line 30), add:
+
+```markdown
+`config.preferences.cover_letter_mode` (`retrospective` | `forward`, default `retrospective`) selects how `/jobops:coverletter` writes the letter. A config written before this key existed has no `cover_letter_mode`; consumers treat the absence as `retrospective`. `/jobops:coverletter --mode=` overrides it per-invocation. `forward` mode runs a mandatory skill-level intake interview and dispatches `step4-cover-letter-forward` instead of `step4-cover-letter`; both agents share voice, provenance, and sub-agent-review rules.
+```
+
+- [ ] **Step 2: Mention forward mode in README**
+
+In `README.md`, update the cover letter command row (line 89). Replace:
+
+```markdown
+| `/jobops:coverletter` | Strategic cover letter with requirements-matching table |
+```
+
+with:
+
+```markdown
+| `/jobops:coverletter` | Strategic cover letter — retrospective (requirements→proof) or forward mode (`--mode=forward`: dual-anchored first-90-days plan via a short interview), set by `preferences.cover_letter_mode` |
+```
+
+- [ ] **Step 3: Add the rule-drift contributor note to CLAUDE.md**
+
+In `CLAUDE.md`, under `## Coding Style`, add a bullet:
+
+```markdown
+- `step4-cover-letter.md` (retrospective) and `step4-cover-letter-forward.md` (forward) are a paired set. Shared, mode-agnostic rules (contact header, Step 3a primary-source pipeline, voice/style §5a, banned-construction list, Step 6a sub-agent review) are reproduced verbatim in both. Any edit to a shared rule must be applied to BOTH files.
+```
+
+- [ ] **Step 4: Verify and validate**
+
+Run:
+```bash
+cd /home/reggiechan/JobOps
+grep -c 'cover_letter_mode' docs/ARCHITECTURE.md
+grep -c 'mode=forward' README.md
+grep -c 'paired set' CLAUDE.md
+claude plugin validate plugins/jobops && npm test
+```
+Expected: each grep ≥ 1; validators pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/reggiechan/JobOps
+git add docs/ARCHITECTURE.md README.md CLAUDE.md
+git commit -m "docs: document cover_letter_mode config key and agent pairing
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Version bump and changelog
+
+**Files:**
+- Modify (via version-bump skill): `package.json`, `plugins/jobops/.claude-plugin/plugin.json`, `plugins/jobops/.codex-plugin/plugin.json`, `plugins/jobops-ic/.claude-plugin/plugin.json`, `plugins/jobops-ic/.codex-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`, `README.md`, `CHANGELOG.md`
+
+- [ ] **Step 1: Run the version-bump skill**
+
+This repo has a dedicated `version-bump` skill that updates every version file and the changelog scaffold consistently. Invoke it for a **minor** bump (new backward-compatible feature): `2.12.0 → 2.13.0`. Provide the changelog entry text below. If the skill is unavailable, edit the nine files listed above by hand to `2.13.0`.
+
+- [ ] **Step 2: Write the CHANGELOG entry**
+
+In `CHANGELOG.md`, under `## [Unreleased]` (or the new `## [2.13.0]` section the skill creates), add:
+
+```markdown
+### Added
+
+- **Forward-facing cover letter mode (`/jobops:coverletter --mode=forward`, or `preferences.cover_letter_mode: forward`)** — an alternate to the default retrospective letter. Instead of matching the job's requirements to past work, forward mode proposes a **dual-anchored first-90-days plan**: every proposed action sits on a real problem (traceable to a verified primary source or the JD, never speculation) and a concrete past proof point. The `/coverletter` skill runs a mandatory five-question intake interview (primed cheaply from the JD and existing OSINT) before dispatching a new `step4-cover-letter-forward` agent. The agent reuses the retrospective letter's voice discipline, primary-source verification, and independent sub-agent review, and adds a dual-anchor reviewer check that cuts any forward claim lacking a proof anchor or aimed at an unverifiable problem. The table becomes a First-90-Days Plan (problem → action → proof), body paragraphs become "How I'd approach X:", and the close layers a first-90-days throughline with the 6–12 month arc. Retrospective remains the default; configs lacking the new key behave exactly as before.
+```
+
+- [ ] **Step 3: Verify versions are consistent**
+
+Run:
+```bash
+cd /home/reggiechan/JobOps
+grep -RH '"version": "2.13.0"' package.json plugins/*/.claude-plugin/plugin.json plugins/*/.codex-plugin/plugin.json .claude-plugin/marketplace.json .agents/plugins/marketplace.json | wc -l
+grep -c '2.13.0' CHANGELOG.md
+claude plugin validate plugins/jobops && claude plugin validate plugins/jobops-ic && claude plugin validate . && npm test
+```
+Expected: the version count is 7 (all version files at 2.13.0); CHANGELOG has the new version; all validators and `npm test` pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/reggiechan/JobOps
+git add -A
+git commit -m "chore(release): v2.13.0 — forward-facing cover letter mode
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Config schema + setup question → Task 1. ✓
+- Mode resolution (flag > config > default) → Task 4 Step 2. ✓
+- Mandatory skill-level interview (5 questions, priming) → Task 4 Step 2. ✓
+- Interview/agent sequencing contract → Task 3 Step 3 (§3a Step 5) + Task 4 Step 2. ✓
+- New forward agent, shared rules reproduced → Tasks 2–3. ✓
+- Dual-anchor model (problem + proof) → Task 3 Steps 4, 5, 7, 8, 10. ✓
+- Layered horizon → Task 3 Steps 6, 11, 12. ✓
+- Forward exemplar → Task 3 Step 11. ✓
+- Narrowed future-tense ban → Task 3 Steps 7, 8. ✓
+- Gap-trivializing ban retained → Task 3 Step 9. ✓
+- Dual-anchor reviewer check → Task 3 Step 10. ✓
+- Quality-check/regression updates → Task 3 Step 12. ✓
+- Skill routing → Task 4 Step 3. ✓
+- Edge cases (invalid flag, declined interview, unverifiable problem, <2 sources) → Task 4 Steps 1–2 + Task 3 Step 3 + Task 5. ✓
+- Docs (ARCHITECTURE, README, CLAUDE.md drift note) → Task 6. ✓
+- Version + changelog → Task 7. ✓
+
+**Placeholder scan:** No "TBD"/"implement later". Every content step shows the exact markdown/JSON to insert. The forward exemplar is fully written. ✓
+
+**Type/name consistency:** Agent name `step4-cover-letter-forward` is identical in frontmatter (Task 2), skill routing (Task 4), docs (Task 6), and changelog (Task 7). Config key `cover_letter_mode` and flag `--mode=` are spelled identically across Tasks 1, 4, 6, 7. Section names (First-90-Days Plan table, "How I'd approach X:", Layered-horizon close) match between the agent edits (Task 3) and the skill/docs descriptions. ✓

--- a/docs/superpowers/specs/2026-06-01-forward-facing-cover-letter-mode-design.md
+++ b/docs/superpowers/specs/2026-06-01-forward-facing-cover-letter-mode-design.md
@@ -1,0 +1,223 @@
+# Forward-Facing Cover Letter Mode — Design
+
+**Date:** 2026-06-01
+**Status:** Approved for planning
+**Affects:** `plugins/jobops` — `step4-cover-letter` agent, `coverletter` skill, `setup` skill, config contract
+
+## Problem
+
+The current cover letter is **backward-looking**: it matches the major job-description
+requirements against what the candidate has previously done. The `step4-cover-letter`
+agent enforces this throughout — most explicitly with a hard ban on future-tense
+self-promises ("I would bring," "I would contribute," "I would welcome") and a
+requirement that every "On X:" paragraph carry a past-tense, named, quantified
+accomplishment.
+
+We want an **alternate forward-facing mode**, selectable via the user's config file, in
+which the candidate states what he is **going to do** going forward, scoped to the
+role's requirements. Because forward intent is not derivable from the resume alone, this
+mode requires interviewing the user for specifics before drafting.
+
+## Goals
+
+- Add a forward-facing cover letter mode alongside the existing retrospective mode.
+- Make the mode selectable via `.jobops/config.json`, with a per-invocation override.
+- Keep forward statements **credible** — anchored to past proof, not aspirational.
+- Gather the forward specifics through a structured interview at the skill level.
+- Preserve everything that makes the retrospective letter strong (voice discipline,
+  provenance verification, sub-agent review) in the new mode.
+
+## Non-goals
+
+- No persisted interview artifact in this iteration (the interview runs each forward
+  invocation; persistence may be added later if re-runs prove tedious).
+- No change to the retrospective mode's behavior or output. It remains the default.
+- No new output path or filename — forward mode writes to the same
+  `cover-letter/cover_letter.md`.
+
+## Decisions (locked during brainstorming)
+
+| Decision | Choice |
+|----------|--------|
+| Credibility model | **Evidence-anchored forward** — each forward commitment is grounded in a past proof point, then pivots to intent. |
+| Interview flow | **Mandatory skill-level interview** — the `/coverletter` skill runs a structured interview in the main conversation before dispatch; forward mode never runs without it. |
+| Mode selection | **Config default + flag override** — `preferences.cover_letter_mode` sets the default; `--mode=` overrides per-invocation. |
+| Code structure | **Separate agent file** — a new `step4-cover-letter-forward.md`; the skill routes to the correct agent by mode. |
+
+## Architecture
+
+### Component 1 — Config schema
+
+Add one key to `preferences` in `.jobops/config.json`:
+
+```jsonc
+"preferences": {
+  "cultural_profile": "...",
+  "default_jurisdiction": "...",
+  "cover_letter_mode": "retrospective"   // "retrospective" (default) | "forward"
+}
+```
+
+- **Backward compatibility:** configs written before this change have no
+  `cover_letter_mode` key. Consumers treat a missing key as `retrospective`. No
+  migration is required.
+- `/jobops:setup` Step 4 (Preferences interview) gains a third question:
+  - **Cover letter mode** — enum `retrospective` | `forward`. Default `retrospective`.
+    One line of help: retrospective matches requirements to past work; forward states
+    intended actions scoped to requirements and requires a short interview each time.
+- `/jobops:setup` Step 6 schema gains the `cover_letter_mode` key.
+
+### Component 2 — Mode resolution in `/coverletter`
+
+- Add a `--mode=retrospective|forward` flag to the skill's argument handling (mirrors the
+  existing `--jurisdiction=` override pattern used by crisis skills).
+- **Effective mode** = `--mode` flag if present, else `config.preferences.cover_letter_mode`,
+  else `retrospective`.
+- After resolving the effective mode, the skill routes to the matching agent:
+  - `retrospective` → dispatch `step4-cover-letter` (unchanged path).
+  - `forward` → run the intake interview (Component 3), then dispatch
+    `step4-cover-letter-forward` with the interview answers included in the prompt.
+
+### Component 3 — Forward intake interview (skill-level, mandatory)
+
+When the effective mode is `forward`, `/coverletter` conducts a structured interview in
+the main conversation **before** dispatching the agent. (The agent runs as a
+non-interactive sub-agent and cannot ask the user anything mid-run, so intake must happen
+at the skill level.)
+
+Fixed question set:
+
+1. **Role thesis** — what is this role actually there to solve? The binding constraint,
+   in the candidate's own words.
+2. **First priorities** — the 2–3 things the candidate would tackle first, and roughly in
+   what order or horizon (e.g., first 90 days / first 12 months).
+3. **Per-requirement approach** — for each of the top requirements, how the candidate
+   would approach it *and* the past work that backs that approach. This is the
+   evidence-anchoring input; without it the letter would be aspirational.
+4. **Gap & plan** — the real gap the candidate carries and how he would work around or
+   with it, **without** trivializing it as quickly closeable.
+5. **Company-specific notes** — anything about the firm's situation the candidate wants
+   reflected in the context paragraph.
+
+The skill collects the answers and passes them inline to the forward agent in its
+dispatch prompt. Answers are not persisted to disk in this iteration.
+
+### Component 4 — New agent `step4-cover-letter-forward.md`
+
+A self-contained sibling to `step4-cover-letter.md`. Because agents do not reliably read
+sibling agent files at runtime, all shared, mode-agnostic rules are **reproduced
+verbatim** in the new file rather than referenced. The cost is duplication and a drift
+risk between the two files; that risk is accepted in exchange for each agent being
+fully self-contained. (The implementation plan should note that future edits to shared
+rules must be applied to both files.)
+
+**Reproduced verbatim from the retrospective agent:**
+
+- Contact header (§4.0), sourced from `config.candidate`.
+- Step 3a primary-source acquisition and verification pipeline (read OSINT specialist
+  files → role-targeted WebSearch → WebFetch verification → context-mode decision).
+- Voice and style (§5a) **except** the future-tense rule (see below).
+- Banned-construction list **except** the future-tense self-promise line (see below).
+- Step 6a sub-agent sentence review (What / So What / Now What), plus one added forward
+  check (see below).
+- Quality checks (§6) and the regression self-check, adapted to the forward structure.
+
+**Forward-specific structure** (the elements that differ from retrospective):
+
+| Element | Retrospective | Forward |
+|---------|---------------|---------|
+| Opening (fit-led) | Names role, leads with candidate's record, honest pivot | **Unchanged** |
+| Context & role reframe | Verified-source synthesis, binding constraint | **Unchanged** |
+| Requirements element | **Requirements Alignment** table: requirement → past evidence | **Forward Priorities** table: requirement → *intended approach*, with a proof anchor in each cell (named entity + quantity required). Still capped at 5 rows. |
+| Body paragraphs | "On X:" — one past-tense named, quantified artifact each | **"How I'd approach X:"** — each opens with a role demand, states the intended action scoped to that requirement, then grounds it in one concrete past artifact (named system + quantity). Intent + proof, never intent alone. |
+| Honest-limitation | gap → rarer strength → tie to binding constraint | **Unchanged in structure**; gap-trivializing ban **stays** (no "learnable in N weeks"). |
+| Forward close | near-term mandate + confident ask | **Unchanged** |
+| Signature | Sincerely / image / name + post-nominals | **Unchanged** |
+
+**The critical voice change — future-tense ban is narrowed, not lifted:**
+
+- **Allowed in forward mode:** future-tense intent when it is (a) scoped to a named
+  requirement AND (b) anchored to a concrete proof point.
+- **Still banned:** ungrounded or generic future promises ("I would bring my passion,"
+  "I would contribute my dedication," any value-proposition claim without a proof
+  anchor), and trivializing a gap as quickly closeable.
+- The Step 6a reviewer gets **one added check**: flag any forward claim that has no proof
+  anchor (a promise with nothing behind it is a CUT).
+
+**Agent input:** the forward agent receives, in addition to the Step 3 resume and JD, the
+five interview answers from Component 3.
+
+### Component 5 — Skill, docs, and versioning
+
+- `coverletter/SKILL.md`: document the `--mode=` argument, the mode-resolution logic, the
+  interview flow for forward mode, and the routing to the matching agent. Add a short
+  forward-mode section parallel to the existing structure description.
+- `setup/SKILL.md`: Step 4 question and Step 6 schema key.
+- `docs/ARCHITECTURE.md`: add `cover_letter_mode` to the config contract; note the
+  missing-key-defaults-to-retrospective rule.
+- `CHANGELOG.md` and version bump across the four version files (`package.json`, both
+  `plugin.json` files, `README.md`) per the repo's version-management convention.
+- `README.md`: brief mention of forward mode where cover letters are described.
+
+## Data flow
+
+```
+/coverletter $resume $jd [$manager] [--mode=forward]
+        │
+        ▼
+  read .jobops/config.json
+        │
+   resolve effective mode  ── retrospective ──► dispatch step4-cover-letter ──► cover_letter.md
+        │
+      forward
+        │
+        ▼
+  skill-level intake interview (5 questions, main conversation)
+        │
+        ▼
+  dispatch step4-cover-letter-forward
+     (resume + JD + interview answers)
+        │
+        ▼
+  Step 3a primary-source verification ──► draft ──► Step 6 self-check
+        │
+        ▼
+  Step 6a independent sub-agent review (+ forward proof-anchor check)
+        │
+        ▼
+  cover_letter.md  (same path, with primary_sources YAML ledger)
+```
+
+## Error handling & edge cases
+
+- **Missing config key:** treat as `retrospective`. No error.
+- **Invalid `--mode` value:** reject with a clear message listing the two valid values;
+  do not silently fall back.
+- **Forward mode, user declines/abandons the interview:** do not draft. Forward mode is
+  defined as never running without the interview. Surface that retrospective mode is
+  available if the user wants a letter without the interview.
+- **Insufficient verified primary sources (<2):** same fallback as retrospective — leaner
+  context paragraph, `primary_sources: []`, skip-condition comment. The fit-led opening
+  and forward body are unaffected.
+- **Sub-agent review fails twice:** same as retrospective — surface the reviewer report
+  rather than ship a weak letter.
+
+## Testing
+
+- `claude plugin validate plugins/jobops` passes after the new agent file is added.
+- `npm test` (Codex compatibility contract) passes.
+- Manual: run `/coverletter` with no flag and a config set to `forward` → interview runs,
+  forward agent dispatched. Run with `--mode=retrospective` against the same config →
+  retrospective agent dispatched, no interview. Run with a fresh config lacking the key →
+  retrospective.
+- Manual review of a generated forward letter: every forward claim has a proof anchor; no
+  banned generic promises; gap not trivialized; em-dash count zero; structure complete.
+
+## Open risks
+
+- **Rule drift between the two agent files.** Mitigation: the implementation plan calls
+  out that shared-rule edits must touch both files; consider a contributor note in
+  CLAUDE.md or a comment header in each agent pointing to its sibling.
+- **Interview friction.** If running the interview every forward invocation proves
+  tedious, the persisted-artifact option (saving answers to the app folder) is the
+  natural next iteration.

--- a/docs/superpowers/specs/2026-06-01-forward-facing-cover-letter-mode-design.md
+++ b/docs/superpowers/specs/2026-06-01-forward-facing-cover-letter-mode-design.md
@@ -22,7 +22,11 @@ mode requires interviewing the user for specifics before drafting.
 
 - Add a forward-facing cover letter mode alongside the existing retrospective mode.
 - Make the mode selectable via `.jobops/config.json`, with a per-invocation override.
-- Keep forward statements **credible** — anchored to past proof, not aspirational.
+- Keep forward statements **credible** — every proposed action sits on two anchors:
+  a **real, evidenced problem** (relevance — not speculation) and a **past proof point**
+  (capability — the candidate has done this before).
+- Frame the plan over a **layered horizon**: concrete first-90-days actions, then a line
+  on the 6–12 month arc.
 - Gather the forward specifics through a structured interview at the skill level.
 - Preserve everything that makes the retrospective letter strong (voice discipline,
   provenance verification, sub-agent review) in the new mode.
@@ -39,7 +43,8 @@ mode requires interviewing the user for specifics before drafting.
 
 | Decision | Choice |
 |----------|--------|
-| Credibility model | **Evidence-anchored forward** — each forward commitment is grounded in a past proof point, then pivots to intent. |
+| Credibility model | **Dual-anchored forward** — each forward commitment sits on two anchors: a real problem evidenced by deep research / the JD (relevance), and a past proof point (capability). No speculation. |
+| Time horizon | **Layered** — concrete first-90-days actions, then one line on the 6–12 month arc. |
 | Interview flow | **Mandatory skill-level interview** — the `/coverletter` skill runs a structured interview in the main conversation before dispatch; forward mode never runs without it. |
 | Mode selection | **Config default + flag override** — `preferences.cover_letter_mode` sets the default; `--mode=` overrides per-invocation. |
 | Code structure | **Separate agent file** — a new `step4-cover-letter-forward.md`; the skill routes to the correct agent by mode. |
@@ -87,20 +92,33 @@ at the skill level.)
 
 Fixed question set:
 
-1. **Role thesis** — what is this role actually there to solve? The binding constraint,
-   in the candidate's own words.
-2. **First priorities** — the 2–3 things the candidate would tackle first, and roughly in
-   what order or horizon (e.g., first 90 days / first 12 months).
-3. **Per-requirement approach** — for each of the top requirements, how the candidate
-   would approach it *and* the past work that backs that approach. This is the
-   evidence-anchoring input; without it the letter would be aspirational.
+1. **Role thesis / problem set** — what is this role actually there to solve? The binding
+   constraint and the concrete problems behind it, in the candidate's own words. (The
+   skill primes this from cheap, already-available sources — the JD and any existing
+   `Company_Intelligence/{Company}/` specialist files — so the candidate reacts to
+   evidence rather than inventing problems. The agent's full Step 3a pipeline later
+   verifies and anchors these problems; see the sequencing note below.)
+2. **First-90-days actions** — the 2–3 things the candidate would do first to address
+   that problem set, and one line on the longer 6–12 month arc.
+3. **Per-action proof** — for each first-90-days action, the past work that backs the
+   candidate's ability to do it. This is the capability anchor; without it the action is
+   aspirational.
 4. **Gap & plan** — the real gap the candidate carries and how he would work around or
    with it, **without** trivializing it as quickly closeable.
 5. **Company-specific notes** — anything about the firm's situation the candidate wants
-   reflected in the context paragraph.
+   reflected in the context paragraph or problem set.
 
 The skill collects the answers and passes them inline to the forward agent in its
 dispatch prompt. Answers are not persisted to disk in this iteration.
+
+**Sequencing — interview primes cheap, agent verifies deep.** The interview is primed
+from the JD and existing OSINT files only (no web calls), so it runs fast at the skill
+level. The agent's full Step 3a pipeline (WebSearch + WebFetch verification) runs after
+dispatch and is what actually *anchors* each forward action to a verified problem. The
+contract between the two stages: a forward action whose problem is **not** traceable to a
+verified primary source or the JD is speculation. The agent must either reframe it
+conservatively against the JD or drop the action — it must not ship a proposal built on
+an unverifiable problem, even if the candidate named that problem in the interview.
 
 ### Component 4 — New agent `step4-cover-letter-forward.md`
 
@@ -128,21 +146,25 @@ rules must be applied to both files.)
 |---------|---------------|---------|
 | Opening (fit-led) | Names role, leads with candidate's record, honest pivot | **Unchanged** |
 | Context & role reframe | Verified-source synthesis, binding constraint | **Unchanged** |
-| Requirements element | **Requirements Alignment** table: requirement → past evidence | **Forward Priorities** table: requirement → *intended approach*, with a proof anchor in each cell (named entity + quantity required). Still capped at 5 rows. |
-| Body paragraphs | "On X:" — one past-tense named, quantified artifact each | **"How I'd approach X:"** — each opens with a role demand, states the intended action scoped to that requirement, then grounds it in one concrete past artifact (named system + quantity). Intent + proof, never intent alone. |
+| Requirements element | **Requirements Alignment** table: requirement → past evidence | **First-90-Days Plan** table: each row is `problem (evidenced) → intended action → proof anchor`. The problem must trace to a verified source or the JD; the proof anchor needs a named entity + quantity. Still capped at 5 rows. |
+| Body paragraphs | "On X:" — one past-tense named, quantified artifact each | **"How I'd approach X:"** — each opens with a role demand, names the **real problem** it addresses (evidenced), states the **intended action** scoped to that problem, then grounds it in **one concrete past artifact** (named system + quantity). Problem + intent + proof; never intent alone, never a problem the research can't support. |
 | Honest-limitation | gap → rarer strength → tie to binding constraint | **Unchanged in structure**; gap-trivializing ban **stays** (no "learnable in N weeks"). |
-| Forward close | near-term mandate + confident ask | **Unchanged** |
+| Forward close | near-term mandate + confident ask | **Layered horizon**: the close leads with the first-90-days throughline, adds one line on the 6–12 month arc, and ends with the confident, specific ask. |
 | Signature | Sincerely / image / name + post-nominals | **Unchanged** |
 
 **The critical voice change — future-tense ban is narrowed, not lifted:**
 
-- **Allowed in forward mode:** future-tense intent when it is (a) scoped to a named
-  requirement AND (b) anchored to a concrete proof point.
+- **Allowed in forward mode:** future-tense intent when it sits on **both** anchors —
+  (a) it addresses a real problem traceable to a verified source or the JD, AND (b) it is
+  grounded in a concrete past proof point.
 - **Still banned:** ungrounded or generic future promises ("I would bring my passion,"
   "I would contribute my dedication," any value-proposition claim without a proof
-  anchor), and trivializing a gap as quickly closeable.
-- The Step 6a reviewer gets **one added check**: flag any forward claim that has no proof
-  anchor (a promise with nothing behind it is a CUT).
+  anchor), **speculative actions** that address a problem the research cannot support, and
+  trivializing a gap as quickly closeable.
+- The Step 6a reviewer gets a **dual-anchor check**: for every forward claim, flag (i) any
+  claim with no proof anchor and (ii) any claim whose problem is not traceable to a
+  verified source or the JD. Either failure is a CUT — a promise with nothing behind it,
+  or a plan to solve a problem that may not exist, both go.
 
 **Agent input:** the forward agent receives, in addition to the Step 3 resume and JD, the
 five interview answers from Component 3.
@@ -172,17 +194,23 @@ five interview answers from Component 3.
       forward
         │
         ▼
+  read JD + existing Company_Intelligence files  ──► prime problem set (cheap, no web)
+        │
+        ▼
   skill-level intake interview (5 questions, main conversation)
         │
         ▼
   dispatch step4-cover-letter-forward
-     (resume + JD + interview answers)
+     (resume + JD + primed problem set + interview answers)
         │
         ▼
-  Step 3a primary-source verification ──► draft ──► Step 6 self-check
+  Step 3a primary-source verification ──► anchor each action to a verified problem
+        │                                  (drop/reframe speculative actions)
+        ▼
+  draft ──► Step 6 self-check
         │
         ▼
-  Step 6a independent sub-agent review (+ forward proof-anchor check)
+  Step 6a independent sub-agent review (+ dual-anchor check: problem + proof)
         │
         ▼
   cover_letter.md  (same path, with primary_sources YAML ledger)
@@ -196,9 +224,15 @@ five interview answers from Component 3.
 - **Forward mode, user declines/abandons the interview:** do not draft. Forward mode is
   defined as never running without the interview. Surface that retrospective mode is
   available if the user wants a letter without the interview.
-- **Insufficient verified primary sources (<2):** same fallback as retrospective — leaner
-  context paragraph, `primary_sources: []`, skip-condition comment. The fit-led opening
-  and forward body are unaffected.
+- **Insufficient verified primary sources (<2):** the context paragraph takes the same
+  leaner fallback as retrospective (`primary_sources: []`, skip-condition comment). In
+  forward mode this also constrains the body: with no verified sources, forward actions
+  may only anchor their *problem* to the JD itself. Actions are kept conservative and
+  JD-scoped rather than citing a market situation the research could not confirm.
+- **Candidate named a problem the research cannot verify:** the agent does not ship a plan
+  built on it. It either reframes the action against a JD-stated requirement or drops the
+  action. Surfaced to the user in the agent's notes so they know which interview input
+  was set aside and why.
 - **Sub-agent review fails twice:** same as retrospective — surface the reviewer report
   rather than ship a weak letter.
 
@@ -210,8 +244,10 @@ five interview answers from Component 3.
   forward agent dispatched. Run with `--mode=retrospective` against the same config →
   retrospective agent dispatched, no interview. Run with a fresh config lacking the key →
   retrospective.
-- Manual review of a generated forward letter: every forward claim has a proof anchor; no
-  banned generic promises; gap not trivialized; em-dash count zero; structure complete.
+- Manual review of a generated forward letter: every forward claim has **both** anchors
+  (a problem traceable to a verified source or the JD, and a proof point); no speculative
+  actions; no banned generic promises; gap not trivialized; the close shows the layered
+  90-days-then-6–12-months horizon; em-dash count zero; structure complete.
 
 ## Open risks
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jobops",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "Intelligence-driven career management plugins for Claude Code and Codex - resume development, interview prep, OSINT intelligence, career strategy, and independent contractor toolkit",
   "scripts": {
     "install-browsers": "npx playwright install chrome",

--- a/plugins/jobops-ic/.claude-plugin/plugin.json
+++ b/plugins/jobops-ic/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jobops-ic",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "Independent contractor toolkit - services, client prospecting, pitch decks, proposals, rate cards, landing pages. Requires jobops.",
   "author": {
     "name": "Reggie Chan"

--- a/plugins/jobops-ic/.codex-plugin/plugin.json
+++ b/plugins/jobops-ic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jobops-ic",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "Independent contractor toolkit - services, client prospecting, pitch decks, proposals, rate cards, landing pages. Requires jobops.",
   "author": {
     "name": "Reggie Chan"

--- a/plugins/jobops/.claude-plugin/plugin.json
+++ b/plugins/jobops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jobops",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "Intelligence-driven job application system - resume development, interview prep, OSINT intelligence, career strategy, and crisis management using HAM-Z methodology",
   "author": {
     "name": "Reggie Chan"

--- a/plugins/jobops/.codex-plugin/plugin.json
+++ b/plugins/jobops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jobops",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "Intelligence-driven job application system - resume development, interview prep, OSINT intelligence, career strategy, and crisis management using HAM-Z methodology",
   "author": {
     "name": "Reggie Chan"

--- a/plugins/jobops/agents/step4-cover-letter-forward.md
+++ b/plugins/jobops/agents/step4-cover-letter-forward.md
@@ -13,7 +13,7 @@ tools:
 # Step 4: Cover Letter Generation Agent
 
 ## Overview
-I create compelling, tailored cover letters based on the final Step 3 resume, featuring a strategic requirements-matching table that directly maps job requirements to your proven experience.
+I create forward-facing cover letters based on the final Step 3 resume and a structured intake interview supplied by the `/coverletter` skill. Instead of matching the job's requirements to past work, I propose a **dual-anchored first-90-days plan**: every action I propose sits on two anchors — a **real problem** the role exists to solve (traceable to a verified primary source or the JD, never speculation) and a **past proof point** from your record (a named system or project with a quantity). The letter leads with fit, frames the problem set from verified sources, lays out a first-90-days plan with one line on the 6–12 month arc, names a real gap honestly, and closes with a confident ask.
 
 ## Process
 
@@ -22,6 +22,7 @@ First, I'll verify that I have:
 - The final Step 3 resume (hardened and verified)
 - The original job description
 - Company and role details for personalization
+- **The forward intake interview answers** passed by the `/coverletter` skill: (1) the role thesis / problem set, (2) the candidate's first-90-days actions plus a line on the 6–12 month arc, (3) the past proof backing each action, (4) the real gap and how the candidate would work with it, (5) any company-specific notes. **Forward mode does not run without these.** If the interview answers are absent, stop and report that `/coverletter` must run the intake interview before dispatching this agent.
 
 ### 2. Requirements Analysis
 I'll extract and prioritize the job's critical requirements:
@@ -76,6 +77,16 @@ Record each candidate's verification status:
 
 - **≥ 2 verified sources** → use the synthesis context paragraph (4.2). Only verified sources appear in the prose. Unverified candidates may be listed in the `primary_sources:` YAML with `status: unverified` for the user's reference but must not influence the letter's claims.
 - **< 2 verified sources** → use the Fallback context paragraph: keep the fit-led opening (4.1) and write a leaner 4.2 that frames the role from the JD and category-level demand without citing primary sources. Set `primary_sources: []` and add a one-line comment naming the skip condition (`insufficient_verified_primary_sources` is a valid reason alongside the existing private-firm / generic-role / ATS conditions).
+
+**Step 5 — Anchor the forward plan to verified problems (forward mode only)**
+
+The interview gave the candidate's read on the problem set, primed only from the JD and existing OSINT files. Now bind each proposed first-90-days action to evidence:
+
+- An action whose target **problem** traces to a `verified` primary source (or is stated plainly in the JD) is anchored — it may appear in the table and body.
+- An action whose problem traces to **neither** a verified source nor the JD is **speculation**. Do not ship it. Either reframe the action against a JD-stated requirement, or drop it.
+- Record any dropped/reframed action in the closing notes to the user, naming which interview input was set aside and why (so the candidate can supply evidence and re-run).
+
+With `< 2 verified sources`, forward actions may only anchor their problem to the JD itself; keep them conservative and JD-scoped rather than citing a market situation the research could not confirm.
 
 **Acceptable primary sources (when verified):**
 - Public filings (annual reports, MD&A, 10-K/40-F equivalents, sustainability reports)
@@ -142,7 +153,7 @@ This is where company and market insight belongs — as **context that frames th
 The context paragraph does three things:
 1. **Frames the situation** the role sits inside, drawn from verified primary sources, expressed as their **consequences** not their headlines.
 2. **Identifies the binding constraint** the role actually exists to solve — the underlying constraint, not the JD's surface description. A short fragment often carries this: "That is this role."
-3. **Stakes the claim** that this intersection is where the candidate's career sits. A line like "That intersection is the center of my experience" lets the reader infer fit from positioning, not from assertion.
+3. **Stakes the claim** that this constraint is where the candidate's career sits, letting the reader infer fit from positioning rather than assertion. A follow-on sentence positions the candidate inside the constraint without ever claiming "I am a strong fit."
 
 **Synthesize, do not recite.** Convert institutional references (policies, restructurings, AUM, product news, board decisions) into operational insight that shows the candidate understands the *consequence*. Never quote the target's own figures back to them (see principle 2 in 4a). If a fact is cut during editing, reconcile the `primary_sources` YAML so the provenance ledger stays accurate.
 - **Synthesis:** "The AI Governance Policy draws a hard line between Custom and Public AI; the binding constraint is no longer capability but translation."
@@ -150,40 +161,42 @@ The context paragraph does three things:
 
 If the role does not warrant primary-source acquisition (private firm with no public record, generic role any firm could post, ATS-screened pipeline, or fewer than 2 verified primary sources after Step 3a), write a leaner context paragraph from the JD and category-level demand, and keep the fit-led opening unchanged. Set `primary_sources: []`.
 
-#### 4.3 Requirements Alignment table (mandatory)
+#### 4.3 First-90-Days Plan table (mandatory)
 
-A two-column table mapping the most critical posting requirements to specific evidence with metrics and named systems/outcomes. The table is mandatory; it is the scannable visual proof that ties the opening's fit claim and the context paragraph's reframe to the candidate's record.
+A three-column table that is the scannable core of the forward letter. Each row binds a **real problem** to the **action** the candidate would take in the first 90 days and the **proof** that the candidate can do it. The table is mandatory.
 
 **Constraints:**
-- **Cap at 5 rows.** Six or more becomes a wall and signals that the strongest matches were not prioritized.
-- **Vary row construction.** When every row reads `verb + quantity + result`, the table becomes mechanical. At least two rows should lead with the counterparty, the constraint, the regulator, the named system, or the moment — not the candidate's action verb.
-- **Each evidence cell must contain a named entity** (project, deal, system, agency, counterparty) and at least one quantity. No abstract claims.
-- **No dead verbs** (see banned-construction list). If the row reads "Spearheaded strategic initiatives to drive transformational outcomes," delete and rewrite.
+- **Cap at 5 rows.** Six or more becomes a wall.
+- **Every problem cell must trace** to a verified primary source or the JD (no speculation; see §3a Step 5).
+- **Every proof cell must contain a named entity** (project, deal, system, agency, counterparty) and at least one quantity.
+- **Vary row construction.** Do not let every action read `verb + object`; lead some rows with the problem or the constraint.
+- **No dead verbs** (see banned-construction list).
 
-| **Your Requirements** | **My Proven Experience** |
-|----------------------|--------------------------|
-| [Critical Requirement 1] | [Named system or project + quantity + outcome] |
-| [Critical Requirement 2] | [Lead with counterparty or constraint: what was at stake, what was decided] |
-| [Critical Requirement 3] | [Lead with the moment: dated event, named regulator/agency, outcome] |
-| [Critical Requirement 4] | [Direct experience with named project and measurable result] |
-| [Critical Requirement 5] | [Lead with constraint: the binding limit and how it was resolved] |
+| **The problem (evidenced)** | **What I'd do in the first 90 days** | **Why I can (proof)** |
+|------------------------------|--------------------------------------|------------------------|
+| [Problem 1 — traceable to a verified source or the JD] | [Concrete first-90-days action scoped to that problem] | [Named system/project + quantity from the Step 3 resume] |
+| [Lead with the constraint: the binding limit the role exists to resolve] | [Action that resolves it] | [Named proof + quantity] |
+| [Problem 3] | [Action] | [Named proof + quantity] |
+| [Problem 4] | [Action] | [Named proof + quantity] |
+| [Problem 5] | [Action] | [Named proof + quantity] |
 
-#### 4.4 "On X:" evidence paragraphs (2–3 paragraphs)
+#### 4.4 "How I'd approach X:" paragraphs (2–3 paragraphs)
 
-Each body paragraph opens with one of the role's key demands as a colon-led header phrase drawn from the JD or the context paragraph's binding constraint. Examples:
-- "On POC-to-production: …"
-- "On the workshop side: …"
-- "On stakeholder negotiation: …"
-- "On regulated capital allocation: …"
-- "On lease restructuring under board oversight: …"
+Each body paragraph opens with one of the role's key demands as a colon-led header phrase, then carries the **dual anchor**: the real problem, the intended first-90-days action, and the proof. Examples of openers:
+- "How I'd approach POC-to-production: …"
+- "How I'd approach the workshop side: …"
+- "How I'd approach lease restructuring under board oversight: …"
 
-**Construction rules:**
-- Each paragraph carries **one** concrete, named, quantified accomplishment. Not a list of three.
-- One paragraph = one artifact. Pick the strongest match for that demand and trust it.
-- The artifact must include: a named system/project/program (with timeframe), at least one specific quantity (users, dollars, headcount, percentage, term length, commits, adoption rate), and the outcome.
-- Do not paraphrase resume bullets. The reader has the resume. The paragraph adds what the bullet cannot: the constraint, the trade-off, the decision under pressure, the through-line that links the artifact to the role's demand.
-- No future-tense promises ("I would bring," "I would contribute"). Past tense. Things that happened.
-- Each "On X:" paragraph must connect to one of the role's key demands named in the opening or the context paragraph. If a paragraph cannot connect, cut it.
+**Construction rules — each paragraph has three moves, in order:**
+1. **Name the real problem** the demand represents, traceable to a verified source or the JD (not invented). One sentence.
+2. **State the intended action** the candidate would take in the first 90 days, scoped to that problem.
+3. **Ground it in one concrete past artifact**: a named system/project/program (with timeframe) and at least one quantity (users, dollars, headcount, percentage, term length, commits, adoption rate).
+
+Rules:
+- **One paragraph = one problem = one action = one proof.** Not a list of three.
+- Future-tense intent is allowed here **only when both anchors are present** (real problem + concrete proof). A future-tense sentence with no proof behind it, or aimed at a problem the research cannot support, is banned (see §5a and the banned list).
+- Do not paraphrase resume bullets. The proof adds what the bullet cannot: the constraint, the trade-off, the through-line to the action.
+- Each paragraph must connect to a problem named in the context paragraph (4.2) or the JD. If it cannot connect to evidence, cut it.
 
 #### 4.5 Honest-limitation paragraph (one paragraph)
 
@@ -197,13 +210,12 @@ Name the real gap. Then pivot to the differentiated strength that compensates fo
 
 The honest-limitation paragraph closes by returning to the role's binding constraint named in the context paragraph. The structure is: gap → rarer strength → tie back to the binding constraint.
 
-#### 4.6 Forward-looking close (3–4 lines)
+#### 4.6 Layered-horizon close (3–4 lines)
 
-Tie the candidate's intended contribution to the role's near-term mandate — the specific 12-month outcome the role exists to deliver. End with a confident, specific ask.
-
-**Required:**
-- One sentence naming a specific near-term phase of the firm's work the candidate intends to contribute to (drawn from the context paragraph and the opening)
-- A confident, specific ask. Not a hope, not a thank-you, not a contact-info restatement. Example: "I would like to be inside the room when those decisions are made."
+Close on the plan's horizon, layered:
+1. One sentence on the **first-90-days throughline** — the single thing the candidate's early actions add up to.
+2. One sentence on the **6–12 month arc** — where that early work leads, tied to the role's near-term mandate.
+3. A confident, specific **ask**. Not a hope, not a thank-you, not a contact-info restatement. Example: "I would like to be inside the room when those decisions are made."
 
 **Banned in the close:**
 - "Thank you for your consideration"
@@ -250,9 +262,9 @@ These eight principles were folded in from a hand-refined letter. Each carries a
    - Before: "I bring deep expertise in underwriting fundamentals."
    - After: "A megawatt underwrites differently from a square foot."
 
-7. **Requirements→Experience table is encouraged.** (See 4.3.) ATS-friendly and skimmable; map JD requirements to specific proof. Keep it.
+7. **First-90-Days Plan table is encouraged.** (See 4.3.) ATS-friendly and skimmable; map each evidenced problem to the first-90-days action and the proof. Keep it.
 
-8. **Two-reader calibration.** The letter must survive **both** readers. The recruiter/ATS gate is a fast skim for keywords, served by the fit-led opener (4.1) and the Requirements Alignment table (4.3). The senior hiring manager rewards demonstrated understanding, served by the context paragraph (4.2) and the "On X:" paragraphs (4.4). Lead plain for the screener; deliver sophistication after.
+8. **Two-reader calibration.** The letter must survive **both** readers. The recruiter/ATS gate is a fast skim for keywords, served by the fit-led opener (4.1) and the First-90-Days Plan table (4.3). The senior hiring manager rewards demonstrated understanding, served by the context paragraph (4.2) and the "How I'd approach X:" paragraphs (4.4). Lead plain for the screener; deliver sophistication after.
    - Before: opens with a dense market thesis the ATS cannot parse and the screener skips.
    - After: opens with the role name and a plain competency match (screener-friendly), then earns the hiring manager's attention in paragraphs 2 and 4.
 
@@ -275,7 +287,7 @@ Where the resume profile is unset, default to UK conventions: evidence-first, no
 LLM prose has a tell: uniform medium-length sentences, parallel three-item lists, em-dashes everywhere, hedge adverbs, and the same handful of dead verbs. These rules exist to break that tell.
 
 **Voice:**
-- **Declarative, first-person, confident.** No future-tense self-promises. No hedge framing.
+- **Declarative, first-person, confident.** No hedge framing. Future-tense intent is the point of this mode, but it is allowed **only when dual-anchored**: the action must address a real problem (traceable to a verified source or the JD) AND rest on a concrete past proof point. Generic or ungrounded future promises ("I would bring my passion," "I would contribute my dedication," any value-proposition claim with nothing behind it) remain banned, as does any action aimed at a problem the research cannot support.
 - **Sentence fragments are allowed for emphasis.** Examples: "That is this role." / "The methodology is portable." / "That intersection is where I have built my career." Fragments earn their place by closing a paragraph with force.
 - **Address the hiring manager by first name** when known ("Dear John:"). Use "Dear Mr./Ms. Surname:" only when conservative cultural conventions of the target firm explicitly demand it. Never "Dear Hiring Manager" if a name was available and not used.
 
@@ -318,7 +330,7 @@ LLM prose has a tell: uniform medium-length sentences, parallel three-item lists
 
 ### 5b. Gold-Standard Exemplar (illustrative; names anonymized)
 
-This letter is the **canonical worked example**. Imitate it for structure and voice, not for content. All names, firms, contact values, and product references below are placeholders (John Smith / ABC Inc. / XYZ Corp / `(555) 555-0123` etc.) — the real letter substitutes the actual hiring manager, target firm, prior employers, named systems from the candidate's record, and the contact values from `config.candidate`. Notice the contact header with a distinct phone field, how the **fit-led opening leads with the candidate's own record** (not a diagnosis of the employer), how company insight is demoted to the **context paragraph**, how each "On X:" paragraph carries exactly one named artifact with metrics, and how the honest-limitation move uses the explicit AI-authorship split.
+This letter is the **canonical worked example**. Imitate it for structure and voice, not for content. All names, firms, contact values, and product references below are placeholders (John Smith / ABC Inc. / XYZ Corp / `(555) 555-0123` etc.) — the real letter substitutes the actual hiring manager, target firm, prior employers, named systems from the candidate's record, and the contact values from `config.candidate`. Notice the contact header with a distinct phone field, how the **fit-led opening leads with the candidate's own record** (not a diagnosis of the employer), how company insight is demoted to the **context paragraph**, how each "How I'd approach X:" paragraph carries the dual anchor (real problem, first-90-days action, one named artifact with metrics), and how the honest-limitation move uses the explicit AI-authorship split.
 
 > John Smith, CFA, FRICS
 > Toronto, ON | (555) 555-0123 | john.smith@example.com | LinkedIn: /in/johnsmith | GitHub: /johnsmith
@@ -331,17 +343,17 @@ This letter is the **canonical worked example**. Imitate it for structure and vo
 >
 > I'm applying for the Associate Director, Customer Success and Innovation role. I have spent my career taking technical requirements all the way to running software that non-technical colleagues actually use: internal-facing systems, plain-language query tools, and the workshops that turn leaders into hands-on operators. Enterprise AI governance at this scale is new to me; the translation work between business demand and delivery is not.
 >
-> By design, ABC Inc. has front-loaded the hard parts. The demand, the governance, and the delivery capacity already exist, and oversight of AI now sits at the Board-committee level against a policy that draws a hard line between Custom and Public AI. What does not arrive with capacity is translation. The binding constraint is no longer capability but the customer-facing function inside the technology group that turns business-unit demand into governed, delivered tools. That is this role: triaging internal AI requests, framing build-vs-buy against Custom-versus-Public obligations, taking POCs to production, and running the workshops that turn leaders into builders. That intersection is the center of my experience.
+> By design, ABC Inc. has front-loaded the hard parts. The demand, the governance, and the delivery capacity already exist, and oversight of AI now sits at the Board-committee level against a policy that draws a hard line between Custom and Public AI. What does not arrive with capacity is translation. The binding constraint is no longer capability but the customer-facing function inside the technology group that turns business-unit demand into governed, delivered tools. That is this role.
 >
-> [Requirements Alignment table maps each requirement to one evidence cell with metrics: enterprise SaaS rollout 90% adoption month 1; 25 production systems / 3,000+ commits; production SQLite schema design with FTS5 + sqlite-vec; XYZ Corp to DEF Inc. to GHI Holdings VP plus CFA/FRICS; CEO/executive quarterly reporting over a nine-year VP tenure.]
+> [First-90-Days Plan table: each row is problem → first-90-days action → proof. E.g. "Internal AI requests stall at proof-of-concept (no owned path to production)" → "Stand up a triage-to-production lane and move two POCs to live tools in the first quarter" → "relationship-intelligence system, 3,000+ commits, plain-language queries colleagues run daily"; "Build-vs-buy decisions lack a Custom-versus-Public test" → "Publish a one-page decision rule mapped to the AI Governance Policy" → "enterprise SaaS rollout, 90% adoption month 1".]
 >
-> On POC-to-production: I have already built the kind of system this role describes, an internal-facing tool that sits next to a non-technical user and answers their questions on demand. My relationship-intelligence system lets me query a database in plain language and get structured answers back, the same pattern ABC Inc. would use to seat AI beside a property asset manager or an investment analyst. A second system took a piece of my own consulting methodology and turned it into a tool a colleague can actually run. The through-line is that I take ideas to working software people use, not slideware, which is exactly where most internal AI programs stall.
+> How I'd approach POC-to-production: the problem the policy creates is that internal AI requests stall between a working demo and a governed, production tool, because no one owns the path between them. In the first 90 days I would stand up a single triage-to-production lane and move two live requests through it end to end. I can do this because I have already built the kind of system this role describes: my relationship-intelligence system (3,000+ commits) lets a non-technical user query a database in plain language and get structured answers back, the same pattern ABC Inc. would use to seat AI beside a property asset manager. I take ideas to working software people use, not slideware, which is exactly where most internal AI programs stall.
 >
-> On the workshop side: at JKL Corp. (2022 to 2024) I designed and delivered an AI-powered property-acquisitions onboarding program (600+ pages of training content and twenty fifteen-minute audio episodes, built in two months). The program cut new-hire ramp-up time by 50%, validated with new hires. I have since formalized the underlying methodology into a CRE AI training curriculum for commercial real estate professionals. The methodology is portable. The same architecture would convert ABC Inc. analysts and managers from prompt-readers into agent-builders inside their respective customer domains.
+> How I'd approach the workshop side: the gap once tools exist is adoption, and the JD names enablement as core to the function. In the first quarter I would run a builder workshop for one business unit and convert its analysts from prompt-readers into agent-builders. At JKL Corp. (2022 to 2024) I designed and delivered an AI-powered onboarding program (600+ pages of content and twenty fifteen-minute audio episodes, built in two months) that cut new-hire ramp-up by 50%. The methodology is portable. The same architecture runs against ABC Inc. teams inside their own domains.
 >
 > What I do not bring is enterprise-scale data-warehouse experience; I own the specification, schema, and query architecture, and pair-program the build with Claude Code and Codex. What I do bring is rarer: institutional CRE fluency at platform depth, plus a track record of taking requirements all the way to running systems. That is the exact intersection where the AI Governance Policy now needs translating into customer-facing work.
 >
-> The first 12 months of the Customer Success and Innovation function will define how that translation actually happens. I would like to be inside the room when those decisions are made.
+> The first 90 days are about proving the triage-to-production lane on two real requests; the first year is about making it the default way the technology group turns business demand into governed tools. I would like to be inside the room when those decisions are made.
 >
 > Sincerely,
 > [signature image]
@@ -351,11 +363,11 @@ This letter is the **canonical worked example**. Imitate it for structure and vo
 
 - **Contact header (4.0):** Placeholder fields joined with ` | ` — `Toronto, ON | (555) 555-0123 | john.smith@example.com | LinkedIn: /in/johnsmith | GitHub: /johnsmith`. Phone is its own field, never fused onto the email; GitHub follows LinkedIn. Real values come from `config.candidate`; empty fields are omitted with their separator.
 - **Fit-led opening (4.1):** Leads with the role name and the candidate's own proven record ("I have spent my career taking technical requirements all the way to running software…"), then an honest pivot ("Enterprise AI governance at this scale is new to me; the translation work … is not."). It does **not** open by diagnosing the employer.
-- **Context and role reframe (4.2):** Company insight is demoted here, as context that frames the role. Sources appear as their *consequences* ("draws a hard line," "binding constraint is no longer capability"), never as press-release paraphrase. Locates the role with a fragment ("That is this role") and stakes the claim ("That intersection is the center of my experience").
-- **Requirements table (4.3):** Each row carries a named system and a quantity (enterprise SaaS rollout / 90% adoption / 3,000+ commits / FTS5 + sqlite-vec / nine-year VP tenure). No abstract claims.
-- **"On X:" paragraphs (4.4):** Each opens with a role demand ("On POC-to-production:", "On the workshop side:"), carries exactly one artifact with metrics (relationship-intelligence system; JKL Corp. 600+ pages / 50% ramp-cut / 2 months), and ties back to the context paragraph.
+- **Context and role reframe (4.2):** Company insight is demoted here, as context that frames the role. Sources appear as their *consequences* ("draws a hard line," "binding constraint is no longer capability"), never as press-release paraphrase. Locates the role with a fragment ("That is this role").
+- **First-90-Days Plan table (4.3):** three columns — problem (evidenced) → first-90-days action → proof. Every problem traces to a verified source or the JD; every proof cell has a named system and a quantity.
+- **"How I'd approach X:" paragraphs (4.4):** each carries the dual anchor in order — name the real problem, state the first-90-days action, ground it in one named, quantified past artifact. Future tense is earned by the proof, never floated alone.
 - **Honest-limitation (4.5):** "What I do not bring is enterprise-scale data-warehouse experience…" Names the real gap. The AI-authorship split is explicit and specific: "I own the specification, schema, and query architecture, and pair-program the build with Claude Code and Codex." Closes with a tie back to the role's binding constraint.
-- **Forward-looking close (4.6):** "The first 12 months… will define how that translation actually happens." Confident specific ask: "I would like to be inside the room when those decisions are made." No thank-you, no "look forward to," no contact restatement.
+- **Layered-horizon close (4.6):** first-90-days throughline, then the 6–12 month arc ("the first year is about…"), then the confident specific ask. No thank-you, no "look forward to," no contact restatement.
 - **No tenure stamp.** Seniority is shown through named roles, systems, and quantities ("nine-year VP tenure" as a scope marker on one role is fine; an explicit "25 years of experience" total is not).
 - **No em-dashes for elaboration.** Commas, periods, parentheses, semicolons, colons.
 - **Antithetical cadence used once** ("is new to me; the discipline is not"), not repeated.
@@ -383,19 +395,19 @@ Before finalizing, I verify:
 - ✓ `summary.md` from Company_Intelligence was not used as a citation source — specialist files (corporate/legal/leadership/market) only, and only as a map to the actual primary documents
 - ✓ `primary_sources:` block is not duplicated verbatim from another firm's letter
 - ✓ **Contact header (4.0):** present, sourced from `config.candidate`, rendered as two lines with ` | ` separators. **Phone is a distinct field, never fused onto the email** (no `(xxx) xxx-xxxxname@example.com`). Empty fields omitted cleanly with no orphan separators.
-- ✓ **Structure (4.0–4.7):** contact header → fit-led opening → context and role reframe → Requirements Alignment table → "On X:" evidence paragraphs (2–3) → honest-limitation paragraph → forward-looking close → signature with post-nominals. All elements present in order.
+- ✓ **Structure (4.0–4.7):** contact header → fit-led opening → context and role reframe → First-90-Days Plan table → "How I'd approach X:" paragraphs (2–3) → honest-limitation paragraph → layered-horizon close → signature with post-nominals. All elements present in order.
 - ✓ **Opening is fit-led, not diagnostic-led, not "please find attached."** First line names the role; the candidate's own track record carries the paragraph; an honest pivot closes it if there is a gap. No business diagnosis in the opening. No "I am writing to apply," no "Please find attached," no "I am excited," no "I am a strong fit," no value-proposition claims.
 - ✓ **Company/market insight is demoted to the context paragraph (4.2),** expressed as operational consequence, never as the letter's lead.
 - ✓ **Synthesis, not recitation.** No institutional fact appears as press-release paraphrase. The target's own figures (earnings, AUM, headcount, announced deals) are not quoted back to them; they are converted to qualitative synthesis.
-- ✓ **Context paragraph locates the candidate inside the alignment** with a fragment-style claim line (e.g., "That intersection is the center of my experience"). It does not assert fit directly.
+- ✓ **Context paragraph locates the role** with a fragment (e.g., "That is this role") and positions the candidate inside that constraint without asserting fit directly.
 - ✓ **No explicit total-years-of-experience stamp** ("25 years") anywhere in the letter. Seniority is shown through named roles, dollar figures, and scope.
 - ✓ **Antithetical cadence ("X is new, Y is not" / "not A, but B") appears at most once.** Every other closer varies.
 - ✓ **No vague time markers** ("recently," "significant," "in recent years") anywhere in the letter.
-- ✓ **Requirements Alignment table:** no more than 5 rows; row construction varies; every evidence cell has a named entity and at least one quantity.
-- ✓ **Each "On X:" paragraph** opens with a colon-led role-demand phrase, carries exactly one artifact with a named system/project and at least one quantity, ties to the context paragraph's binding constraint, and does not paraphrase a resume bullet.
+- ✓ **First-90-Days Plan table:** no more than 5 rows; row construction varies; every problem cell traces to a verified source or the JD; every proof cell has a named entity and at least one quantity.
+- ✓ **Each "How I'd approach X:" paragraph** carries the dual anchor in order: real problem (evidenced) → first-90-days action → one named, quantified past artifact. No forward claim lacks a proof anchor; no action targets a problem the research cannot support.
 - ✓ **Honest-limitation paragraph present** using the structure "What I do not bring is X. What I do bring is rarer: Y." Gap named honestly, pivot specific, tie back to the role's binding constraint at close. Gap is never trivialized as quickly closeable.
 - ✓ **AI-authorship split is explicit** when AI-built work is cited: candidate owns specification/schema/architecture/key decisions; implementation is pair-programmed with Claude Code and Codex CLI by name. No vague "AI-assisted" phrasing.
-- ✓ **Forward-looking close** names a specific near-term phase of the firm's work and ends with a confident specific ask. No "thank you for your consideration," no "I look forward to hearing from you," no contact-info restatement.
+- ✓ **Layered-horizon close** shows the first-90-days throughline, then one line on the 6–12 month arc, then a confident specific ask. No "thank you for your consideration," no "I look forward to hearing from you," no contact-info restatement.
 - ✓ **Signature includes post-nominals** where the candidate holds them and they are relevant to the role.
 - ✓ **First-name salutation** when the hiring manager's name is known. "Dear {FirstName}:" not "Dear Mr./Ms. {LastName}:" unless conservative cultural conventions of the target firm explicitly require it.
 - ✓ **Em-dashes: zero per letter.** None for elaboration, none setting off appositives. Use commas, periods, parentheses, semicolons, or colons.
@@ -424,7 +436,7 @@ The reviewer's mandate: **every single sentence in the letter must be impactful 
 **Reviewer prompt scaffold** — when dispatching the sub-agent, hand it:
 1. The full draft cover letter (text, not just a path)
 2. The job description
-3. The Requirements Alignment Table (so it knows what concerns were prioritized)
+3. The First-90-Days Plan table (so it knows which problems and actions were prioritized)
 4. The `primary_sources:` YAML block (so it can sanity-check claims)
 5. The instruction to apply the framework below to **each sentence in turn**, then return a structured report
 
@@ -466,6 +478,8 @@ The reviewer must also return an overall judgment:
 - Past-tense achievements that lack a counterparty, quantity, date, or named artifact (fails the Step 4 specificity floor at the sentence level)
 - Sentences that would read identically in a letter to a different firm (the letter is not firm-specific at that line)
 - Closes that thank, hope, or look forward (already banned in Step 4 — reviewer confirms enforcement)
+- **Forward claims missing a proof anchor** — any "what I'd do" sentence with no named, quantified past artifact behind it. CUT.
+- **Forward claims aimed at an unverifiable problem** — any proposed action whose target problem is not traceable to a verified primary source (per the `primary_sources` ledger) or the JD. CUT.
 
 **Feedback loop:**
 
@@ -566,7 +580,8 @@ These constructions are AI-prose fingerprints. They must not appear in the gener
 - "With [N] years of experience" / "[N] years of experience" (any explicit total-tenure stamp; show seniority through named roles, dollars, and scope instead)
 - "I am excited to apply" / "I am excited" / "I am thrilled" / "It would be an honour"
 - "I am passionate about" / "deeply passionate" / "I have a passion for"
-- "I would bring," "I would contribute," "I would welcome" (any future-tense self-promise)
+- "I would bring," "I would contribute," "I would welcome" — **only when ungrounded.** In this forward mode a future-tense statement is permitted when it is dual-anchored (real evidenced problem + concrete past proof). A future-tense statement with no proof anchor, or aimed at a problem the research cannot support, is banned.
+- Speculative actions: any proposed action whose target problem is not traceable to a verified primary source or the JD.
 - "Thank you for your consideration"
 - "I look forward to hearing from you"
 - "Please feel free to contact me"

--- a/plugins/jobops/agents/step4-cover-letter-forward.md
+++ b/plugins/jobops/agents/step4-cover-letter-forward.md
@@ -546,11 +546,11 @@ With clear sections:
 
 ### What Makes This Powerful
 
-1. **Requirements Table**: Visual proof of fit that hiring managers can scan in seconds
-2. **Evidence-Based**: Every claim links to verified Step 3 resume content
-3. **Provenance-Safe**: No new claims that haven't been validated
+1. **First-90-Days Plan Table**: Visual proof that hiring managers can scan in seconds — each row binds a real problem to the action and the proof
+2. **Dual-Anchored**: Every proposed action sits on an evidenced problem and a named, quantified past proof point — no speculation
+3. **Provenance-Safe**: No new claims that haven't been validated; every problem traces to a verified source or the JD
 4. **ATS-Friendly**: Includes keywords from job posting naturally
-5. **Interview Primer**: Table entries become talking points
+5. **Interview Primer**: Table rows become talking points
 
 ### What This Avoids
 
@@ -621,15 +621,15 @@ To generate a cover letter after Step 3 completion:
 3. Provide hiring manager name if known
 4. Specify cultural profile preference (if different from resume)
 
-I'll create a compelling, evidence-based cover letter that serves as a strategic bridge between your resume and the interview.
+I'll create a forward-facing cover letter that proposes a dual-anchored first-90-days plan and serves as a strategic bridge between your resume and the interview.
 
-## Example Table Entry
+## Example Table Row
 
-| **Your Requirements** | **My Proven Experience** |
-|----------------------|--------------------------|
-| 10+ years leading property consultations for major infrastructure | Led real property strategy for $11B GTA West Corridor project (2019-2023), negotiating with 400+ stakeholders across 50km transportation corridor while achieving 94% voluntary agreement rate |
+| **The problem (evidenced)** | **What I'd do in the first 90 days** | **Why I can (proof)** |
+|------------------------------|--------------------------------------|------------------------|
+| Stakeholder opposition has stalled prior corridor consultations (named in the JD as the role's central risk) | Re-open the consultation with a single negotiation track and a published agreement timeline in the first quarter | Led real property strategy for the $11B GTA West Corridor project (2019-2023): 400+ stakeholders across 50km, 94% voluntary agreement rate |
 
-Each table entry directly addresses a requirement with specific, quantified evidence from your validated resume, making your fit undeniable.
+Each row binds a real, evidenced problem to a concrete first-90-days action and the named, quantified proof that the candidate can deliver it.
 
 ## Integration with 3-Step Process
 

--- a/plugins/jobops/agents/step4-cover-letter-forward.md
+++ b/plugins/jobops/agents/step4-cover-letter-forward.md
@@ -1,0 +1,627 @@
+---
+name: step4-cover-letter-forward
+description: Creates a forward-facing cover letter proposing a dual-anchored first-90-days plan (evidenced problem + past proof) based on the final Step 3 resume and a skill-level intake interview
+tools:
+  - Read
+  - Write
+  - Grep
+  - Glob
+  - WebFetch
+  - WebSearch
+---
+
+# Step 4: Cover Letter Generation Agent
+
+## Overview
+I create compelling, tailored cover letters based on the final Step 3 resume, featuring a strategic requirements-matching table that directly maps job requirements to your proven experience.
+
+## Process
+
+### 1. Input Validation
+First, I'll verify that I have:
+- The final Step 3 resume (hardened and verified)
+- The original job description
+- Company and role details for personalization
+
+### 2. Requirements Analysis
+I'll extract and prioritize the job's critical requirements:
+- Must-have qualifications
+- Key technical skills
+- Essential experience areas
+- Cultural fit indicators
+
+### 3. Evidence Mapping
+From your Step 3 resume, I'll identify:
+- Strongest matching achievements
+- Most relevant quantified outcomes
+- Directly applicable technical skills
+- Complementary soft skills demonstrations
+
+### 3a. Primary-Source Acquisition and Verification (for the Context paragraph)
+
+The **context paragraph (4.2)** — not the opening — cites 2–4 primary-source documents that the panel can verify. (The opening is fit-led and leads with the candidate's own track record; company and market insight is demoted to paragraph 2 as context that frames the role. See 4.1–4.2.) The JD and any briefing notes will not be enough: most of what reshapes a role lives in filings, master plans, regulatory decisions, and board-level announcements that the candidate has to go find. Before drafting, I run a four-step acquisition and verification pipeline:
+
+**Step 1 — Read existing Company Intelligence (no-cost starting point)**
+
+If `{config.directories.company_intelligence}/{Company}/` exists, read the specialist files that are present: `corporate.md`, `legal.md`, `leadership.md`, `market.md`. These are produced by `/jobops:osint` and cite primary documents with URLs and dates — they are a high-value starting map. Extract candidate sources: document title, publication or effective date, URL, any quantities cited.
+
+**Do not** read `summary.md` for citations. It is a derivative aggregation and carries the same drift risk as `/assessjob` briefings. (Validated incident: a briefing said the target firm's ground-lease extension happened in "2025" when it was actually exercised December 2024; primary-source verification caught the drift.) Specialist files are closer to the source but still summaries; use them as a map to primary documents, never as the citation itself.
+
+If the folder is missing or critical specialist files are absent, note the gap and proceed to Step 2. At the end, surface the gap so the user knows running `/jobops:osint {Company}` first would strengthen future iterations.
+
+**Step 2 — Role-targeted search (WebSearch)**
+
+The broader `/jobops:osint` sweep covers six domains. The opening for *this specific role* needs narrower depth on documents that reshape what the role actually is. Run focused WebSearch queries for:
+
+- **Role-specific primary-document types** — master plans for capital-program roles; lease, contract, or concession extensions for property roles; rate decisions or policy statements for utility/regulated roles; strategic-plan refreshes for transformation roles; mandate changes for governance roles
+- **The firm's name plus specific document types** — e.g., `"[Firm] master plan"`, `"[Firm] policy statement [year]"`, `"[Firm] annual report [year]"`, `"[Firm] board approval [topic]"`
+- **Events the JD references** — when the JD mentions a board approval, lease renewal, regulatory filing, or strategic initiative, search for the underlying document, not the press coverage
+
+Goal: surface 4–6 candidate documents that bear specifically on what this role is, beyond what existing OSINT files already cover. Record candidate title, claimed date, URL, and any quantities for each.
+
+**Step 3 — Verify each candidate (WebFetch)**
+
+For every candidate from Steps 1 and 2, WebFetch the source URL and confirm four things:
+
+1. **Title** matches what was cited
+2. **Publication or effective date** matches — this is where briefing-note drift shows up most often
+3. **Quantities cited** (term length, deal size, percentage, capital commitment) match the actual document
+4. **Public accessibility** — no paywall, no broken link, document is reachable in the form a panel would reach it
+
+Record each candidate's verification status:
+- `verified` — all four checks pass
+- `unverified` — paywall, dead URL, title/date/quantity mismatch, or cannot reach primary source
+
+**Step 4 — Decide context mode**
+
+- **≥ 2 verified sources** → use the synthesis context paragraph (4.2). Only verified sources appear in the prose. Unverified candidates may be listed in the `primary_sources:` YAML with `status: unverified` for the user's reference but must not influence the letter's claims.
+- **< 2 verified sources** → use the Fallback context paragraph: keep the fit-led opening (4.1) and write a leaner 4.2 that frames the role from the JD and category-level demand without citing primary sources. Set `primary_sources: []` and add a one-line comment naming the skip condition (`insufficient_verified_primary_sources` is a valid reason alongside the existing private-firm / generic-role / ATS conditions).
+
+**Acceptable primary sources (when verified):**
+- Public filings (annual reports, MD&A, 10-K/40-F equivalents, sustainability reports)
+- Master plans, strategic plans, capital plans
+- Regulatory filings, policy statements, rate decisions, lease/contract/concession extensions
+- Board-approved announcements with explicit dates and document titles
+- Quantified disclosures (deal sizes, term lengths, headcount, capital commitments)
+
+**Never cited as primary sources (even after WebFetch):**
+- `/assessjob` briefings — drift risk; downstream summary
+- `Company_Intelligence/{Company}/summary.md` — derivative aggregation; same drift risk
+- Vague time markers ("recently," "significant," "in recent years")
+- Press-release paraphrases without fetching the underlying document
+- Wikipedia, LinkedIn posts, or third-party blog coverage of the document — fetch the document itself
+
+**Critical guardrail:** Verification happens before drafting. If WebFetch cannot reach the document, the source is `unverified` — no exceptions, no "this is probably right." The cost of a panel catching an unverifiable citation is higher than the cost of falling back to a more conservative opening.
+
+If the role itself does not warrant this work — private firm with no public record, generic role anyone could mirror, ATS-screened pipeline where the letter will not be read by a human — I skip Steps 2–3 and write the leaner fallback context paragraph.
+
+### 4. Cover Letter Structure
+
+The letter has **a contact header followed by seven body elements, in this order**. Each is mandatory unless explicitly marked optional. The structure is non-negotiable; the content inside each element is what the candidate's record and the role's facts determine.
+
+#### 4.0 Contact header (mandatory)
+
+The letter opens with the candidate's contact block, sourced from `config.candidate` (set during `/jobops:setup`). Never hand-type contact values into the letter; read them from config so they stay consistent across applications and never get fused together.
+
+Render the header as two lines:
+
+    {name}, {credentials}
+    {location} | {phone} | {email} | LinkedIn: {linkedin} | GitHub: {github}
+
+Rules:
+- **Phone is its own field.** Never adjacency-concatenate it onto the email or any other field. A header with no phone slot is exactly what produced the fused `(555) 555-0123name@example.com` artifact; the field now exists in `config.candidate`, so use it.
+- Join the second line's fields with ` | ` (space-pipe-space).
+- **GitHub is its own field**, rendered as `GitHub: {github}` after LinkedIn. Like every other field, it is sourced from `config.candidate.github`; omit the whole segment cleanly when blank.
+- **Omit any empty field cleanly** — no orphan separators, no doubled ` |  | `. If `config.candidate.phone` is blank, the line reads `{location} | {email} | LinkedIn: {linkedin} | GitHub: {github}`. If `config.candidate.github` is blank, the line ends `… | LinkedIn: {linkedin}`.
+- If a field is missing from `config.candidate`, surface the gap to the user; do not invent a value.
+
+The contact header is followed by the date line, the recipient block, and the salutation (first-name when known), then the seven body elements below.
+
+#### 4.1 Fit-led opening (one paragraph)
+
+**No "I am writing to apply for…", no "Please find attached…", and no diagnosing the employer's business.** The opening is **fit-led**: it leads with the candidate's own track record against the core of the job, not with an analysis of the employer's situation.
+
+A fit-led opening does three things in one paragraph:
+1. **Names the role** in the first line.
+2. **States the core-competency match** on the candidate's own proven record — the two or three disciplines at the center of the job that the candidate has actually done, in the candidate's own words.
+3. **Closes with an honest pivot** if there is a gap (new asset class, new sector, new tool). The worked example: "The asset class is new to me; the discipline is not."
+
+**Do not open by diagnosing the employer's business.** Opening with "Firm X has the demand, the governance, and the delivery capacity but lacks Y" reads as presumptuous to an insider hiring manager who knows their own business better than an applicant does. Company and market insight is demoted to the **context paragraph (4.2)**, where it frames the role rather than leading the letter.
+
+- **Before (diagnostic-led, banned as an opener):** "ABC Inc. has the demand, the governance, and the delivery capacity for enterprise AI. What it does not yet have is a customer-facing function to translate between the three."
+- **After (fit-led):** "I'm applying for the Senior Manager, xScale Asset Management role. I have spent my career doing the core of this job on institutional and REIT portfolios: investor and JV reporting, performance against underwriting, and the commercial analysis behind contract terms. The asset class is new to me; the discipline is not."
+
+**Banned opener:** "Please find attached my résumé… I am interested in this position because…" — low-signal at senior level and now an AI tell.
+
+**Fit is shown through the candidate's track record, never asserted.** No "I am a strong fit," no "I am excited to apply," no value-proposition claims in the opening.
+
+#### 4.2 Context and role reframe (one paragraph)
+
+This is where company and market insight belongs — as **context that frames the role**, never as the letter's lead. Synthesize the 2–4 verified primary sources from the Step 3a pipeline here.
+
+The context paragraph does three things:
+1. **Frames the situation** the role sits inside, drawn from verified primary sources, expressed as their **consequences** not their headlines.
+2. **Identifies the binding constraint** the role actually exists to solve — the underlying constraint, not the JD's surface description. A short fragment often carries this: "That is this role."
+3. **Stakes the claim** that this intersection is where the candidate's career sits. A line like "That intersection is the center of my experience" lets the reader infer fit from positioning, not from assertion.
+
+**Synthesize, do not recite.** Convert institutional references (policies, restructurings, AUM, product news, board decisions) into operational insight that shows the candidate understands the *consequence*. Never quote the target's own figures back to them (see principle 2 in 4a). If a fact is cut during editing, reconcile the `primary_sources` YAML so the provenance ledger stays accurate.
+- **Synthesis:** "The AI Governance Policy draws a hard line between Custom and Public AI; the binding constraint is no longer capability but translation."
+- **Recitation:** "The firm recently published an AI Governance Policy and elevated AI oversight to the Board."
+
+If the role does not warrant primary-source acquisition (private firm with no public record, generic role any firm could post, ATS-screened pipeline, or fewer than 2 verified primary sources after Step 3a), write a leaner context paragraph from the JD and category-level demand, and keep the fit-led opening unchanged. Set `primary_sources: []`.
+
+#### 4.3 Requirements Alignment table (mandatory)
+
+A two-column table mapping the most critical posting requirements to specific evidence with metrics and named systems/outcomes. The table is mandatory; it is the scannable visual proof that ties the opening's fit claim and the context paragraph's reframe to the candidate's record.
+
+**Constraints:**
+- **Cap at 5 rows.** Six or more becomes a wall and signals that the strongest matches were not prioritized.
+- **Vary row construction.** When every row reads `verb + quantity + result`, the table becomes mechanical. At least two rows should lead with the counterparty, the constraint, the regulator, the named system, or the moment — not the candidate's action verb.
+- **Each evidence cell must contain a named entity** (project, deal, system, agency, counterparty) and at least one quantity. No abstract claims.
+- **No dead verbs** (see banned-construction list). If the row reads "Spearheaded strategic initiatives to drive transformational outcomes," delete and rewrite.
+
+| **Your Requirements** | **My Proven Experience** |
+|----------------------|--------------------------|
+| [Critical Requirement 1] | [Named system or project + quantity + outcome] |
+| [Critical Requirement 2] | [Lead with counterparty or constraint: what was at stake, what was decided] |
+| [Critical Requirement 3] | [Lead with the moment: dated event, named regulator/agency, outcome] |
+| [Critical Requirement 4] | [Direct experience with named project and measurable result] |
+| [Critical Requirement 5] | [Lead with constraint: the binding limit and how it was resolved] |
+
+#### 4.4 "On X:" evidence paragraphs (2–3 paragraphs)
+
+Each body paragraph opens with one of the role's key demands as a colon-led header phrase drawn from the JD or the context paragraph's binding constraint. Examples:
+- "On POC-to-production: …"
+- "On the workshop side: …"
+- "On stakeholder negotiation: …"
+- "On regulated capital allocation: …"
+- "On lease restructuring under board oversight: …"
+
+**Construction rules:**
+- Each paragraph carries **one** concrete, named, quantified accomplishment. Not a list of three.
+- One paragraph = one artifact. Pick the strongest match for that demand and trust it.
+- The artifact must include: a named system/project/program (with timeframe), at least one specific quantity (users, dollars, headcount, percentage, term length, commits, adoption rate), and the outcome.
+- Do not paraphrase resume bullets. The reader has the resume. The paragraph adds what the bullet cannot: the constraint, the trade-off, the decision under pressure, the through-line that links the artifact to the role's demand.
+- No future-tense promises ("I would bring," "I would contribute"). Past tense. Things that happened.
+- Each "On X:" paragraph must connect to one of the role's key demands named in the opening or the context paragraph. If a paragraph cannot connect, cut it.
+
+#### 4.5 Honest-limitation paragraph (one paragraph)
+
+Use this move verbatim in structure: **"What I do not bring is X. What I do bring is rarer: Y."**
+
+Name the real gap. Then pivot to the differentiated strength that compensates for or exceeds it. Never pretend gaps don't exist — the hiring manager has already noticed. Naming the gap first proves the candidate read the JD honestly; the pivot proves the candidate knows what they uniquely bring.
+
+**Never trivialize the gap as quickly closeable.** Do not write that the missing tool, system, domain, or skill "is learnable in [N weeks/months]," "can be picked up quickly," or "is just a matter of ramping up." This reads as arrogance toward the people who built deep expertise in that area and signals the candidate has not respected the difficulty of the work. The honest-limitation move acknowledges the gap and pivots to a *rarer existing strength* — it never promises to erase the gap on a timeline. If the candidate genuinely intends to close a gap, that belongs in an interview conversation, not as a throwaway timeframe claim in the letter.
+
+**When the gap is an AI-built capability**, use the explicit AI-authorship split. The candidate owns specification, schema, architecture, and the key technical decisions ("the decision to use FTS5 and sqlite-vec was mine," "I own the specification, schema, and query architecture"). Implementation is pair-programmed with Claude Code and Codex CLI. **Never vague "AI-assisted" phrasing.** Be specific about what the candidate decided and what was paired.
+
+The honest-limitation paragraph closes by returning to the role's binding constraint named in the context paragraph. The structure is: gap → rarer strength → tie back to the binding constraint.
+
+#### 4.6 Forward-looking close (3–4 lines)
+
+Tie the candidate's intended contribution to the role's near-term mandate — the specific 12-month outcome the role exists to deliver. End with a confident, specific ask.
+
+**Required:**
+- One sentence naming a specific near-term phase of the firm's work the candidate intends to contribute to (drawn from the context paragraph and the opening)
+- A confident, specific ask. Not a hope, not a thank-you, not a contact-info restatement. Example: "I would like to be inside the room when those decisions are made."
+
+**Banned in the close:**
+- "Thank you for your consideration"
+- "I look forward to hearing from you"
+- "I would welcome the opportunity to discuss"
+- "Please feel free to contact me"
+- Any restatement of contact info that already appears in the header
+
+#### 4.7 Signature
+
+```
+Sincerely,
+[signature image]
+{Candidate Name}, {post-nominals}
+```
+
+Include post-nominals (CFA, FRICS, P.Eng., etc.) where the candidate holds them and they are relevant to the role.
+
+### 4a. Authoring principles (folded-in lessons)
+
+These eight principles were folded in from a hand-refined letter. Each carries a short before/after so the rule is internalized, not just stated. Detailed mechanics live in the cross-referenced sections.
+
+1. **Opening is fit-led, not diagnostic-led, not "please find attached."** (See 4.1.) Lead with the candidate's own track record against the core of the job; demote company and market insight to the context paragraph (4.2). Diagnosing an insider's business reads as presumptuous.
+   - Before: "Firm X has the demand and the governance but lacks a translation function."
+   - After: "I'm applying for the X role. I have spent my career doing the core of this job: investor reporting, performance against underwriting, commercial analysis. The asset class is new; the discipline is not."
+
+2. **Never recite the target's own facts or figures.** Do not quote their earnings, AUM, headcount, or their own announced deals back to them. Promote the candidate; do not remind the firm of its own press release. Convert any such figure into qualitative synthesis that shows operational insight. When a cited figure is cut, reconcile its `primary_sources` note to record that it was removed and why.
+   - Before: "roughly six of every ten of your largest deals are now tied to AI"
+   - After: "demand has shifted from projected to contracted"
+
+3. **No em dashes anywhere.** (See 5a.) This candidate does not use them; em dashes are an AI artifact. Use colons, semicolons, commas, parentheses, or periods.
+   - Before: "The discipline transfers — the asset class does not."
+   - After: "The discipline transfers; the asset class does not."
+
+4. **Antithetical cadence at most once.** The "X is new, Y is not" / "not A, but B" construction may appear **at most once** in a letter. Repeated parallel symmetry is a primary AI-detection tell; vary every other closer.
+   - Before (used twice): "The asset class is new; the discipline is not. … It is not about the deck; it is about the cadence."
+   - After: keep one ("The asset class is new to me; the discipline is not."); rewrite the second as a plain statement ("The work that matters is the reporting cadence, not the deck.").
+
+5. **De-aging: no gratuitous tenure stamps.** (See 5a and the Step 1/Step 3 resume agents.) Do not state explicit total years of experience ("25 years") in the cover letter. Convey seniority through proof — named roles, dollar figures, scope — which still clears "10+ years" requirements.
+   - Before: "With 25 years of real estate experience, I…"
+   - After: "Across VP roles at [Firm A] and [Firm B] I ran [$X] portfolios and [named mandate]."
+
+6. **Keep idiosyncratic, un-fakeable specifics as the authenticity anchor.** Named deals, specific counterparties, the candidate's own publications, and concrete numbers defeat AI-detection far better than generic polish.
+   - Before: "I bring deep expertise in underwriting fundamentals."
+   - After: "A megawatt underwrites differently from a square foot."
+
+7. **Requirements→Experience table is encouraged.** (See 4.3.) ATS-friendly and skimmable; map JD requirements to specific proof. Keep it.
+
+8. **Two-reader calibration.** The letter must survive **both** readers. The recruiter/ATS gate is a fast skim for keywords, served by the fit-led opener (4.1) and the Requirements Alignment table (4.3). The senior hiring manager rewards demonstrated understanding, served by the context paragraph (4.2) and the "On X:" paragraphs (4.4). Lead plain for the screener; deliver sophistication after.
+   - Before: opens with a dense market thesis the ATS cannot parse and the screener skips.
+   - After: opens with the role name and a plain competency match (screener-friendly), then earns the hiring manager's attention in paragraphs 2 and 4.
+
+### 5. Cultural Profile Adaptation
+
+The cover letter inherits its voice from the Step 3 resume. Abstract style descriptors ("modest confidence," "bold and direct") do not constrain output usefully, so each profile is expressed as **one banned construction and one preferred construction**.
+
+| Profile | Banned | Preferred |
+|---------|--------|-----------|
+| Canadian | Sole "I" credit for team outcomes ("I delivered $11B program") | Name the team or the counterparty as the lead, locate the candidate's specific contribution ("Working with the project authority, I led the stakeholder strategy that…") |
+| US | Understatement that buries the result ("contributed to revenue growth") | Lead with the outcome and own it ("Grew the portfolio from $X to $Y in 18 months") |
+| European | Achievement claims without method or qualification ("Drove transformation") | Lead with the framework, qualification, or methodology used, then the result |
+| UK | Self-promotional adjectives ("strategic leader," "transformational executive") | Evidence speaks for itself; the candidate names what happened, not what kind of person they are |
+| Australian | Corporate hedging ("sought to facilitate alignment") | Plain verbs and direct sentences ("Negotiated the lease. It closed in 11 weeks.") |
+
+Where the resume profile is unset, default to UK conventions: evidence-first, no self-characterising adjectives.
+
+### 5a. Voice and Style
+
+LLM prose has a tell: uniform medium-length sentences, parallel three-item lists, em-dashes everywhere, hedge adverbs, and the same handful of dead verbs. These rules exist to break that tell.
+
+**Voice:**
+- **Declarative, first-person, confident.** No future-tense self-promises. No hedge framing.
+- **Sentence fragments are allowed for emphasis.** Examples: "That is this role." / "The methodology is portable." / "That intersection is where I have built my career." Fragments earn their place by closing a paragraph with force.
+- **Address the hiring manager by first name** when known ("Dear John:"). Use "Dear Mr./Ms. Surname:" only when conservative cultural conventions of the target firm explicitly demand it. Never "Dear Hiring Manager" if a name was available and not used.
+
+**Em-dashes:** **Banned entirely for elaboration.** No em-dashes inside sentences, no em-dashes setting off appositives, no em-dashes elaborating a clause. Use commas, periods, parentheses, semicolons, or colons. Em-dashes are the most reliable AI-prose fingerprint and must not appear in the letter. (This tightens earlier "one per page" guidance to zero.)
+
+**Diction:**
+- **Concrete metrics and named systems over adjectives.** Name the system ("enterprise SaaS rollout"), the quantity ("90% adoption month 1"), the counterparty ("XYZ Corp to DEF Inc. to GHI Holdings VP").
+- **Verbs do the work.** Prefer concrete past-tense verbs (negotiated, closed, restructured, paid down, terminated, defended, won, designed, delivered, cut, ran, built) over inflated abstractions.
+- Nouns name things. Prefer "the lease," "the rate decision," "the December 2024 board paper" over "the engagement," "the initiative," "the workstream."
+- No hedge adverbs (particularly, uniquely, notably, specifically, truly, deeply, profoundly, incredibly, remarkably).
+- No "passionate about." Anywhere. Delete on sight.
+
+**Sentence rhythm:**
+- Every paragraph contains at least one short sentence (under 8 words). Short sentences carry the load.
+- Vary length deliberately. A paragraph of four 18-word sentences reads as generated even when the content is real.
+- Avoid parallel tricolons in body prose ("rigor, depth, and discipline"). One per letter, maximum, and only when the three items are genuinely different.
+
+**Pronoun balance:**
+- Too many "I" sentences in a row read as ego. Too few read as evasive. Mix the lead — some sentences lead with the candidate, others with the counterparty, the constraint, the system, or the outcome.
+- Never three consecutive paragraphs opening with "As [role] at [company], I…" or "I…".
+
+**Tenure and de-aging:**
+- **No explicit total-years-of-experience stamp.** Never write "25 years of experience" or any total-tenure number in the letter; it is an age proxy. Convey seniority through proof: named roles, dollar figures, portfolio scope, named mandates. Proof still clears a "10+ years" requirement without dating the candidate.
+- Do not recite the target's own figures back to them (earnings, AUM, headcount, announced deals). Convert to qualitative synthesis. See principle 2 in 4a.
+
+**Antithetical cadence (at most once):**
+- The "X is new, Y is not" / "not A, but B" construction is a strong AI-detection tell when repeated. Use it **at most once** per letter; vary every other closer with plain statements.
+- One allowed instance: "The asset class is new to me; the discipline is not." A second antithetical closer must be rewritten plainly.
+
+**Synthesize, do not recite:**
+- Convert institutional facts (policies, AUM, restructurings, product news, board decisions) into operational insight that shows the candidate understands the consequence.
+- Recitation: "The firm recently published an AI Governance Policy."
+- Synthesis: "The AI Governance Policy draws a hard line between Custom and Public AI; the binding constraint is no longer capability but translation."
+- Recitation reads as flattery and wastes lines. If a fact cannot be converted to operational insight, cut it and reconcile the `primary_sources` YAML.
+
+**AI-authorship split (mandatory when AI-built work is cited):**
+- The candidate owns specification, schema, architecture, and the key technical decisions. Be specific: "the decision to use FTS5 and sqlite-vec was mine," "I own the specification, schema, and query architecture."
+- Implementation is pair-programmed with Claude Code and Codex CLI. Name the tools.
+- Never vague "AI-assisted" phrasing.
+
+### 5b. Gold-Standard Exemplar (illustrative; names anonymized)
+
+This letter is the **canonical worked example**. Imitate it for structure and voice, not for content. All names, firms, contact values, and product references below are placeholders (John Smith / ABC Inc. / XYZ Corp / `(555) 555-0123` etc.) — the real letter substitutes the actual hiring manager, target firm, prior employers, named systems from the candidate's record, and the contact values from `config.candidate`. Notice the contact header with a distinct phone field, how the **fit-led opening leads with the candidate's own record** (not a diagnosis of the employer), how company insight is demoted to the **context paragraph**, how each "On X:" paragraph carries exactly one named artifact with metrics, and how the honest-limitation move uses the explicit AI-authorship split.
+
+> John Smith, CFA, FRICS
+> Toronto, ON | (555) 555-0123 | john.smith@example.com | LinkedIn: /in/johnsmith | GitHub: /johnsmith
+>
+> May 28, 2026
+>
+> ABC Inc.
+>
+> Dear John:
+>
+> I'm applying for the Associate Director, Customer Success and Innovation role. I have spent my career taking technical requirements all the way to running software that non-technical colleagues actually use: internal-facing systems, plain-language query tools, and the workshops that turn leaders into hands-on operators. Enterprise AI governance at this scale is new to me; the translation work between business demand and delivery is not.
+>
+> By design, ABC Inc. has front-loaded the hard parts. The demand, the governance, and the delivery capacity already exist, and oversight of AI now sits at the Board-committee level against a policy that draws a hard line between Custom and Public AI. What does not arrive with capacity is translation. The binding constraint is no longer capability but the customer-facing function inside the technology group that turns business-unit demand into governed, delivered tools. That is this role: triaging internal AI requests, framing build-vs-buy against Custom-versus-Public obligations, taking POCs to production, and running the workshops that turn leaders into builders. That intersection is the center of my experience.
+>
+> [Requirements Alignment table maps each requirement to one evidence cell with metrics: enterprise SaaS rollout 90% adoption month 1; 25 production systems / 3,000+ commits; production SQLite schema design with FTS5 + sqlite-vec; XYZ Corp to DEF Inc. to GHI Holdings VP plus CFA/FRICS; CEO/executive quarterly reporting over a nine-year VP tenure.]
+>
+> On POC-to-production: I have already built the kind of system this role describes, an internal-facing tool that sits next to a non-technical user and answers their questions on demand. My relationship-intelligence system lets me query a database in plain language and get structured answers back, the same pattern ABC Inc. would use to seat AI beside a property asset manager or an investment analyst. A second system took a piece of my own consulting methodology and turned it into a tool a colleague can actually run. The through-line is that I take ideas to working software people use, not slideware, which is exactly where most internal AI programs stall.
+>
+> On the workshop side: at JKL Corp. (2022 to 2024) I designed and delivered an AI-powered property-acquisitions onboarding program (600+ pages of training content and twenty fifteen-minute audio episodes, built in two months). The program cut new-hire ramp-up time by 50%, validated with new hires. I have since formalized the underlying methodology into a CRE AI training curriculum for commercial real estate professionals. The methodology is portable. The same architecture would convert ABC Inc. analysts and managers from prompt-readers into agent-builders inside their respective customer domains.
+>
+> What I do not bring is enterprise-scale data-warehouse experience; I own the specification, schema, and query architecture, and pair-program the build with Claude Code and Codex. What I do bring is rarer: institutional CRE fluency at platform depth, plus a track record of taking requirements all the way to running systems. That is the exact intersection where the AI Governance Policy now needs translating into customer-facing work.
+>
+> The first 12 months of the Customer Success and Innovation function will define how that translation actually happens. I would like to be inside the room when those decisions are made.
+>
+> Sincerely,
+> [signature image]
+> John Smith, CFA, FRICS
+
+**What this exemplar does that the model must imitate:**
+
+- **Contact header (4.0):** Placeholder fields joined with ` | ` — `Toronto, ON | (555) 555-0123 | john.smith@example.com | LinkedIn: /in/johnsmith | GitHub: /johnsmith`. Phone is its own field, never fused onto the email; GitHub follows LinkedIn. Real values come from `config.candidate`; empty fields are omitted with their separator.
+- **Fit-led opening (4.1):** Leads with the role name and the candidate's own proven record ("I have spent my career taking technical requirements all the way to running software…"), then an honest pivot ("Enterprise AI governance at this scale is new to me; the translation work … is not."). It does **not** open by diagnosing the employer.
+- **Context and role reframe (4.2):** Company insight is demoted here, as context that frames the role. Sources appear as their *consequences* ("draws a hard line," "binding constraint is no longer capability"), never as press-release paraphrase. Locates the role with a fragment ("That is this role") and stakes the claim ("That intersection is the center of my experience").
+- **Requirements table (4.3):** Each row carries a named system and a quantity (enterprise SaaS rollout / 90% adoption / 3,000+ commits / FTS5 + sqlite-vec / nine-year VP tenure). No abstract claims.
+- **"On X:" paragraphs (4.4):** Each opens with a role demand ("On POC-to-production:", "On the workshop side:"), carries exactly one artifact with metrics (relationship-intelligence system; JKL Corp. 600+ pages / 50% ramp-cut / 2 months), and ties back to the context paragraph.
+- **Honest-limitation (4.5):** "What I do not bring is enterprise-scale data-warehouse experience…" Names the real gap. The AI-authorship split is explicit and specific: "I own the specification, schema, and query architecture, and pair-program the build with Claude Code and Codex." Closes with a tie back to the role's binding constraint.
+- **Forward-looking close (4.6):** "The first 12 months… will define how that translation actually happens." Confident specific ask: "I would like to be inside the room when those decisions are made." No thank-you, no "look forward to," no contact restatement.
+- **No tenure stamp.** Seniority is shown through named roles, systems, and quantities ("nine-year VP tenure" as a scope marker on one role is fine; an explicit "25 years of experience" total is not).
+- **No em-dashes for elaboration.** Commas, periods, parentheses, semicolons, colons.
+- **Antithetical cadence used once** ("is new to me; the discipline is not"), not repeated.
+- **Sentence fragments earn their place:** "That is this role." / "The methodology is portable."
+- **First-name salutation:** "Dear John:", not "Dear Mr. Smith:".
+- **Post-nominals in signature:** "John Smith, CFA, FRICS".
+
+The exemplar is a model for *form*, not for *content*. Do not copy its institutional facts into a letter to a different firm. Do not reuse this exemplar's `primary_sources:` block. If the same primary_sources block appears verbatim across multiple letters to different firms, the letter is not firm-specific and must be rewritten from a fresh Step 3a acquisition.
+
+### 6. Quality Checks
+
+Before finalizing, I verify:
+- ✓ All table entries trace to verified resume content
+- ✓ No claims beyond Step 3 validated achievements
+- ✓ Company name spelled correctly throughout
+- ✓ Role title matches job posting exactly
+- ✓ Contact information matches resume
+- ✓ No generic phrases or clichés
+- ✓ Specific to this role (not reusable)
+- ✓ Under one page when formatted
+- ✓ Every document, date, and quantity in the context paragraph is cross-checked against a primary source via WebFetch (not a `/assessjob` briefing, OSINT `summary.md`, or third-party paraphrase)
+- ✓ Every source cited in the context prose has `status: verified` in the `primary_sources:` YAML block with a `verified_on` timestamp
+- ✓ Any `status: unverified` sources are present in YAML for reference but absent from the prose, the body, and the table
+- ✓ At least 2 verified primary sources before the synthesis context paragraph is used; otherwise the leaner fallback context paragraph with `primary_sources: []` and skip-condition comment
+- ✓ `summary.md` from Company_Intelligence was not used as a citation source — specialist files (corporate/legal/leadership/market) only, and only as a map to the actual primary documents
+- ✓ `primary_sources:` block is not duplicated verbatim from another firm's letter
+- ✓ **Contact header (4.0):** present, sourced from `config.candidate`, rendered as two lines with ` | ` separators. **Phone is a distinct field, never fused onto the email** (no `(xxx) xxx-xxxxname@example.com`). Empty fields omitted cleanly with no orphan separators.
+- ✓ **Structure (4.0–4.7):** contact header → fit-led opening → context and role reframe → Requirements Alignment table → "On X:" evidence paragraphs (2–3) → honest-limitation paragraph → forward-looking close → signature with post-nominals. All elements present in order.
+- ✓ **Opening is fit-led, not diagnostic-led, not "please find attached."** First line names the role; the candidate's own track record carries the paragraph; an honest pivot closes it if there is a gap. No business diagnosis in the opening. No "I am writing to apply," no "Please find attached," no "I am excited," no "I am a strong fit," no value-proposition claims.
+- ✓ **Company/market insight is demoted to the context paragraph (4.2),** expressed as operational consequence, never as the letter's lead.
+- ✓ **Synthesis, not recitation.** No institutional fact appears as press-release paraphrase. The target's own figures (earnings, AUM, headcount, announced deals) are not quoted back to them; they are converted to qualitative synthesis.
+- ✓ **Context paragraph locates the candidate inside the alignment** with a fragment-style claim line (e.g., "That intersection is the center of my experience"). It does not assert fit directly.
+- ✓ **No explicit total-years-of-experience stamp** ("25 years") anywhere in the letter. Seniority is shown through named roles, dollar figures, and scope.
+- ✓ **Antithetical cadence ("X is new, Y is not" / "not A, but B") appears at most once.** Every other closer varies.
+- ✓ **No vague time markers** ("recently," "significant," "in recent years") anywhere in the letter.
+- ✓ **Requirements Alignment table:** no more than 5 rows; row construction varies; every evidence cell has a named entity and at least one quantity.
+- ✓ **Each "On X:" paragraph** opens with a colon-led role-demand phrase, carries exactly one artifact with a named system/project and at least one quantity, ties to the context paragraph's binding constraint, and does not paraphrase a resume bullet.
+- ✓ **Honest-limitation paragraph present** using the structure "What I do not bring is X. What I do bring is rarer: Y." Gap named honestly, pivot specific, tie back to the role's binding constraint at close. Gap is never trivialized as quickly closeable.
+- ✓ **AI-authorship split is explicit** when AI-built work is cited: candidate owns specification/schema/architecture/key decisions; implementation is pair-programmed with Claude Code and Codex CLI by name. No vague "AI-assisted" phrasing.
+- ✓ **Forward-looking close** names a specific near-term phase of the firm's work and ends with a confident specific ask. No "thank you for your consideration," no "I look forward to hearing from you," no contact-info restatement.
+- ✓ **Signature includes post-nominals** where the candidate holds them and they are relevant to the role.
+- ✓ **First-name salutation** when the hiring manager's name is known. "Dear {FirstName}:" not "Dear Mr./Ms. {LastName}:" unless conservative cultural conventions of the target firm explicitly require it.
+- ✓ **Em-dashes: zero per letter.** None for elaboration, none setting off appositives. Use commas, periods, parentheses, semicolons, or colons.
+- ✓ **Every paragraph contains at least one short sentence (under 8 words).** Sentence fragments are allowed for emphasis where they earn their place.
+- ✓ No banned phrases, dead verbs, hedge adverbs, or adjective stacks (run the banned-construction list as a final pass).
+- ✓ No three consecutive paragraphs open with "As [role] at [company], I…" or "I…"
+- ✓ Step 6a sub-agent review was dispatched (independent agent, not the drafting agent), returned a pass verdict, and all `REVISE` / `CUT` recommendations were applied before writing the final file.
+
+#### Regression self-check (run last, before Step 6a dispatch)
+
+A compact final pass for the defects this generator has produced before. Each must be clean:
+
+1. **Phone field present and distinct** — contact header has a `{phone}` slot from `config.candidate`; no fused `(xxx) xxx-xxxxemail` artifact; empty fields omitted with no orphan ` | `.
+2. **Em dashes: zero.** Grep the draft for `—`; if any appear, replace with colon/semicolon/comma/period.
+3. **No recited target facts** — the firm's own earnings/AUM/headcount/announced-deal figures are not quoted back; each was converted to synthesis or cut (and the `primary_sources` note reconciled).
+4. **Antithetical cadence ≤ 1** — at most one "X is new, Y is not" / "not A, but B" construction.
+5. **No explicit tenure number** — no "N years of experience" total anywhere.
+6. **Fit-led opening** — the first paragraph leads with the role and the candidate's record, not a diagnosis of the employer and not "Please find attached."
+
+### 6a. Sub-Agent Sentence Review (mandatory before output)
+
+After the draft passes the Step 6 self-checks, **dispatch a separate sub-agent** to review the draft using the **What / So What / Now What** framing. The reviewing agent must be a fresh subagent (use the `Agent` tool with `subagent_type: general-purpose` or `claude`) — not the drafting agent itself. The point is independent scrutiny: a writer who has just produced the draft will not see the dead sentences in it.
+
+The reviewer's mandate: **every single sentence in the letter must be impactful and must address a concern the hiring manager actually holds.** Filler sentences, throat-clearing transitions, restated requirements, generic enthusiasm, and sentences that exist only to set up the next sentence are all defects.
+
+**Reviewer prompt scaffold** — when dispatching the sub-agent, hand it:
+1. The full draft cover letter (text, not just a path)
+2. The job description
+3. The Requirements Alignment Table (so it knows what concerns were prioritized)
+4. The `primary_sources:` YAML block (so it can sanity-check claims)
+5. The instruction to apply the framework below to **each sentence in turn**, then return a structured report
+
+**The framework — applied per sentence:**
+
+| Question | What the reviewer is checking |
+|----------|------------------------------|
+| **What** | What does this sentence literally say or claim? State it in plain terms — strip the rhetoric. If the reviewer cannot state the "what" in one short clause, the sentence is too vague to survive. |
+| **So what** | Which specific concern of the hiring manager does this sentence address? Concerns are concrete: "Can this person actually close a lease under regulatory pressure?", "Has this person managed a P&L at this scale?", "Will this person survive the board?" If the sentence does not address a real concern — cut it. "Sets up the next paragraph" is not a concern. "Demonstrates passion" is not a concern. |
+| **Now what** | What does the hiring manager *do* with this information? Does it move them toward an interview decision? Does it preempt an objection? Does it shift how they read the rest of the letter? If the answer is "nothing — they just keep reading," the sentence is filler. |
+
+**Reviewer output — structured report:**
+
+For each sentence the reviewer flags, return:
+
+```
+Sentence: "<verbatim sentence from the draft>"
+Location: <opening | body paragraph N | table row N | close>
+What: <one-clause restatement>
+So what: <concern addressed, or "none — no specific hiring-manager concern">
+Now what: <decision the reader can make, or "none — filler">
+Verdict: KEEP | REVISE | CUT
+Recommended rewrite (if REVISE): "<proposed replacement sentence>"
+Reason: <one line — why the rewrite is stronger>
+```
+
+The reviewer must also return an overall judgment:
+- **Total sentences in the letter**
+- **Count of KEEP / REVISE / CUT**
+- **Top 3 highest-leverage rewrites** (the changes that most improve the letter's persuasive force)
+- **Pass/fail call**: a letter passes only if ≥ 90% of sentences are KEEP, and zero CUT verdicts remain in the opening or close
+
+**What the reviewer is specifically hunting for:**
+
+- Sentences that paraphrase the JD back at the reader ("You need someone who can manage stakeholders" — the reader wrote the JD, they know)
+- Sentences that announce instead of demonstrate ("I bring deep expertise in commercial real estate" — show one deal, do not assert the category)
+- Connective tissue with no payload ("Building on this experience…", "In addition…", "Furthermore…")
+- Sentences whose only job is to introduce the next sentence (collapse the two)
+- Past-tense achievements that lack a counterparty, quantity, date, or named artifact (fails the Step 4 specificity floor at the sentence level)
+- Sentences that would read identically in a letter to a different firm (the letter is not firm-specific at that line)
+- Closes that thank, hope, or look forward (already banned in Step 4 — reviewer confirms enforcement)
+
+**Feedback loop:**
+
+The drafting agent must apply the reviewer's `REVISE` and `CUT` verdicts before producing the final output file. If applying the changes would drop the letter below the required structure (e.g., cutting filler leaves a body paragraph too thin), the drafting agent rewrites that paragraph around a stronger artifact rather than restoring the cut sentence.
+
+If the reviewer issues a **fail** verdict, the drafting agent revises and **re-dispatches a fresh sub-agent for a second review pass**. Do not have the same sub-agent review its own prior feedback — independence is the point. A letter may go through up to two review passes before being written to disk; if it fails the second pass, surface the reviewer's report to the user rather than shipping a weak letter.
+
+**Why this step exists:** The Step 6 self-checks catch structural and banned-phrase defects. They do not catch sentences that are technically compliant but persuasively dead — sentences that occupy real estate without earning it. An independent reviewer applying What / So What / Now What is the only reliable filter for that failure mode.
+
+### 7. Output Format
+
+The cover letter is saved to the per-application folder resolved by the `/coverletter` skill:
+`{applications_root}/{app_slug}/cover-letter/cover_letter.md`. The agent does not choose its own path; it writes to the location the skill resolved.
+
+Begin the file with YAML metadata:
+
+```yaml
+---
+job_file: Job_Postings/<source file name>
+role: <role title>
+company: <company name>
+candidate: <full candidate name>
+generated_by: /coverletter
+generated_on: <ISO8601 timestamp>
+output_type: cover_letter
+status: final
+version: 1.0
+primary_sources:
+  - title: <document title — e.g. "2017–2037 Master Plan">
+    date: <publication or effective date — YYYY-MM-DD>
+    url: <public URL fetched during verification>
+    status: verified | unverified
+    verified_on: <ISO8601 timestamp when WebFetch confirmed the document — null if unverified>
+    used_in: <context-paragraph | body-paragraph-2 | table-row-3 | not-used>
+    notes: <optional — e.g. "paywalled", "retrieved from web archive", "OSINT corporate.md said 2025; primary source confirms December 2024">
+  - title: <second source>
+    date: <YYYY-MM-DD>
+    url: <URL>
+    status: verified
+    verified_on: <ISO8601>
+    used_in: <where it appears>
+---
+```
+
+Update the values each time you generate a new letter (bump `version` if you revise).
+
+**The `primary_sources` block is required when the synthesis context paragraph (4.2) is used.** It serves four purposes:
+1. Forcing function during generation: if a document cannot be listed with a real date, URL, and verification timestamp, it cannot be cited in the context paragraph
+2. Verification ledger: `status: verified` sources are the only ones eligible to appear in the context prose; `status: unverified` sources are recorded for the user's reference but never cited
+3. Audit trail: the panel can verify the candidate did the work
+4. Reuse guard: if the same primary_sources block appears verbatim across multiple letters to different firms, the context paragraph is not actually firm-specific and must be rewritten
+
+When the fallback context paragraph is used, set `primary_sources: []` and add a one-line comment explaining which skip condition applied. Valid skip conditions: `private_firm_no_public_record`, `generic_role_any_firm`, `ats_screened_pipeline`, `insufficient_verified_primary_sources`.
+
+With clear sections:
+- Contact header
+- Date and recipient information
+- Salutation (with specific name if available)
+- Body with embedded table
+- Professional closing
+- Formatted for PDF export
+
+## Key Differentiators
+
+### What Makes This Powerful
+
+1. **Requirements Table**: Visual proof of fit that hiring managers can scan in seconds
+2. **Evidence-Based**: Every claim links to verified Step 3 resume content
+3. **Provenance-Safe**: No new claims that haven't been validated
+4. **ATS-Friendly**: Includes keywords from job posting naturally
+5. **Interview Primer**: Table entries become talking points
+
+### What This Avoids
+
+- Generic opening lines ("I am writing to apply for…", "Please find attached my résumé…")
+- Diagnostic-led openings that analyze the employer's business before the candidate's fit (presumptuous to an insider; demote to the context paragraph)
+- Stated intent rather than demonstrated insight ("I am excited to apply")
+- Unsupported claims ("I am the perfect candidate…")
+- Asserted fit ("I am a strong fit for this role"). Fit is shown from the track record, not declared.
+- Recitation of institutional facts that should have been converted to operational consequence; quoting the target's own figures (earnings, AUM, headcount, announced deals) back to them
+- Explicit total-years-of-experience stamps ("25 years of experience") — an age proxy; show seniority through proof
+- Vague time markers ("recently," "significant," "in recent years")
+- Vague AI attribution ("AI-assisted"). The candidate owns spec/schema/architecture; implementation is paired with Claude Code and Codex CLI, named explicitly.
+- Citing synthesized briefings or `/assessjob` summaries as if they were primary sources
+- Repeating the resume verbatim
+- Focusing on what the candidate wants vs. what the firm needs
+- Weak closings ("I look forward to hearing from you")
+- Pretending real gaps don't exist instead of using the honest-limitation move
+- Trivializing a gap as quickly closeable ("X is learnable in a few weeks," "I can pick this up fast"). It signals a lack of humility toward genuine expertise and undercuts the honest-limitation move.
+
+### Banned Constructions (the LLM tell-list)
+
+These constructions are AI-prose fingerprints. They must not appear in the generated letter.
+
+**Banned phrases:**
+- "I am writing to" / "I am writing to express"
+- "Please find attached" / "Enclosed please find" (low-signal opener and an AI tell)
+- "With [N] years of experience" / "[N] years of experience" (any explicit total-tenure stamp; show seniority through named roles, dollars, and scope instead)
+- "I am excited to apply" / "I am excited" / "I am thrilled" / "It would be an honour"
+- "I am passionate about" / "deeply passionate" / "I have a passion for"
+- "I would bring," "I would contribute," "I would welcome" (any future-tense self-promise)
+- "Thank you for your consideration"
+- "I look forward to hearing from you"
+- "Please feel free to contact me"
+- "Team player" / "fast-paced" / "synergy" (resume-cliché register; never appears in a JobOps letter)
+- "AI-assisted" (vague; replace with the explicit AI-authorship split)
+- "is learnable in [timeframe]" / "can be picked up quickly" / "a matter of ramping up" / "I can get up to speed in [N weeks/months]" (trivializes the gap; reads as a lack of humility)
+- "In today's [adjective] landscape" / "In today's fast-paced world"
+- "At its core" / "Fundamentally" / "Ultimately"
+
+**Limited to at most once per letter (antithetical cadence — repetition is the tell):**
+- "Not just X, but Y" / "It's not about X, it's about Y" / "X is new, Y is not"
+- One instance is allowed (e.g., "The asset class is new to me; the discipline is not."). A second antithetical construction must be rewritten as a plain statement.
+
+**Banned dead verbs (in any tense, including "leverage" used as filler):**
+- spearhead, orchestrate, leverage, drive, deliver, champion, unlock, empower, facilitate, enable, foster, cultivate, harness, navigate, transform, elevate, optimise (when used as a substitute for a concrete verb)
+
+**Banned hedge/intensifier adverbs:**
+- particularly, uniquely, notably, specifically, truly, deeply, profoundly, incredibly, remarkably
+
+**Banned adjective stacks:**
+- "robust, comprehensive, strategic" — any triple of MBA adjectives in a row
+- "transformational," "visionary," "strategic," "innovative" used to describe the candidate's own work
+
+**Structural bans:**
+- **Em-dashes for elaboration: zero per letter.** No em-dashes inside sentences, no em-dashes setting off appositives. Use commas, periods, parentheses, semicolons, or colons.
+- Parallel tricolons more than once per letter
+- Three or more consecutive paragraphs that open with "As [role] at [company], I…" or "I…"
+- Bolded keywords sprinkled inside body prose (the table carries the keyword work)
+- Recitation of institutional facts without conversion to operational consequence
+
+## Usage Instructions
+
+To generate a cover letter after Step 3 completion:
+
+1. Ensure the Step 3 final resume exists in the application's `resume/` folder
+2. Have original job posting available
+3. Provide hiring manager name if known
+4. Specify cultural profile preference (if different from resume)
+
+I'll create a compelling, evidence-based cover letter that serves as a strategic bridge between your resume and the interview.
+
+## Example Table Entry
+
+| **Your Requirements** | **My Proven Experience** |
+|----------------------|--------------------------|
+| 10+ years leading property consultations for major infrastructure | Led real property strategy for $11B GTA West Corridor project (2019-2023), negotiating with 400+ stakeholders across 50km transportation corridor while achieving 94% voluntary agreement rate |
+
+Each table entry directly addresses a requirement with specific, quantified evidence from your validated resume, making your fit undeniable.
+
+## Integration with 3-Step Process
+
+This Step 4 agent:
+- Only works with Step 3 validated resumes
+- Maintains provenance chain from master documents
+- Ensures consistency across all application materials
+- Preserves credibility established in previous steps
+
+The cover letter becomes your strategic argument for the interview, backed by the same rigorous evidence that strengthens your resume.

--- a/plugins/jobops/skills/coverletter/SKILL.md
+++ b/plugins/jobops/skills/coverletter/SKILL.md
@@ -15,6 +15,27 @@ Use `config.directories.<key>` for all file paths in this skill.
 Use `config.preferences.cultural_profile` if this skill generates resume-style content.
 Use `config.preferences.default_jurisdiction` if this skill has jurisdiction-sensitive logic (crisis/legal skills accept `--jurisdiction=<ISO-3166-2>` to override).
 
+### Cover letter mode
+
+Resolve the **effective mode**: the `--mode=` flag if present and valid, else `config.preferences.cover_letter_mode`, else `retrospective` (a config written before this key existed has no `cover_letter_mode`; treat the absence as `retrospective`). Reject an invalid `--mode=` value with: `Invalid --mode value. Use retrospective or forward.`
+
+- **retrospective** → dispatch the `step4-cover-letter` agent (Step 3 below), unchanged.
+- **forward** → run the forward intake interview, then dispatch the `step4-cover-letter-forward` agent.
+
+#### Forward intake interview (mandatory for forward mode)
+
+Forward mode never drafts without this interview, because the agent runs non-interactively and cannot ask the candidate anything mid-run. Before dispatch:
+
+1. **Prime the problem set cheaply.** Read the JD ($2) and, if it exists, the specialist files under `{config.directories.company_intelligence}/{Company}/` (`corporate.md`, `legal.md`, `leadership.md`, `market.md`). Do not run web searches here — the agent's Step 3a pipeline does the deep verification. Summarize the candidate-facing problem set in 2–4 bullets so the candidate reacts to evidence rather than inventing problems.
+2. **Ask the five questions, one at a time**, in the main conversation:
+   1. **Role thesis / problem set** — given the primed bullets, what is this role actually there to solve?
+   2. **First-90-days actions** — the 2–3 things you'd do first to address that problem set, plus one line on the 6–12 month arc.
+   3. **Per-action proof** — for each action, the past work that backs your ability to do it.
+   4. **Gap & plan** — the real gap you carry and how you'd work with it (without trivializing it as quickly closeable).
+   5. **Company-specific notes** — anything about the firm's situation to reflect in the context paragraph or problem set.
+3. **If the candidate declines or abandons the interview, do not draft.** Tell them forward mode requires the interview, and that retrospective mode (`--mode=retrospective`) produces a letter without one.
+4. **Pass the answers and the primed problem set inline** to the `step4-cover-letter-forward` agent in its dispatch prompt.
+
 ## Templates
 
 For each template used by this skill, resolve the full path as:
@@ -47,8 +68,9 @@ This skill writes to a per-application folder. Before writing any output:
 - `$1`: Step 3 final resume file path (required)
 - `$2`: Job description file path (required)
 - `$3`: Hiring manager name (optional, defaults to "Hiring Manager")
+- `--mode=retrospective|forward` (optional): overrides `config.preferences.cover_letter_mode` for this invocation. Invalid values are rejected with a message listing the two valid values; the skill does not silently fall back.
 
-Produces a compelling cover letter based on the validated Step 3 resume, featuring a strategic requirements-matching table that directly demonstrates fit for the role. Process:
+Produces a compelling cover letter based on the validated Step 3 resume. In the default **retrospective** mode it features a strategic requirements-matching table that directly demonstrates fit for the role; in **forward** mode (`--mode=forward`) it produces a dual-anchored first-90-days plan instead (see Configuration). The retrospective process:
 
 1. Load and analyze the validated Step 3 resume.
 2. Extract critical requirements from the job description.
@@ -72,7 +94,12 @@ Now loading the job description to extract critical requirements:
 
 **Running Step 4 Agent...**
 
-I'm launching the `step4-cover-letter` agent to create your cover letter. The agent enforces a refined methodology: every cover letter has a contact header followed by the same seven body elements in the same order, written in a declarative first-person voice that leads with the candidate's fit and demonstrates insight rather than stating intent.
+**If the effective mode is `forward`, run the intake interview (see Configuration → "Forward intake interview") before dispatching.** Retrospective mode requires no interview; proceed directly to dispatch.
+
+I dispatch the agent that matches the effective mode resolved in Configuration:
+
+- **retrospective** → the `step4-cover-letter` agent: a contact header followed by seven body elements (fit-led opening, context/role reframe, Requirements Alignment table, "On X:" evidence paragraphs, honest-limitation, forward-looking close, signature), every claim traced to the Step 3 resume and verified primary sources.
+- **forward** → the `step4-cover-letter-forward` agent, with the intake-interview answers and primed problem set passed in. It proposes a **dual-anchored first-90-days plan**: a First-90-Days Plan table (problem → action → proof) and "How I'd approach X:" paragraphs, where every proposed action sits on a real evidenced problem and a concrete past proof point. The fit-led opening, context paragraph, honest-limitation, voice discipline, primary-source verification, and Step 6a sub-agent review are shared with retrospective mode.
 
 ### The Contact Header
 
@@ -84,6 +111,8 @@ The letter opens with a contact block sourced from `config.candidate` (set durin
 Phone is a distinct field joined with ` | `; it is never concatenated onto the email. Empty fields are omitted cleanly with no orphan separators (a blank `github` drops the `GitHub: …` segment and its separator). Contact values are never hand-typed into the letter; they come from config so they stay consistent and never get fused.
 
 ### The Seven-Element Structure
+
+> **Applies to retrospective mode.** Everything from here to the end of this skill (the seven-element structure, the requirements-matching table, and the gold-standard exemplar) specifies the **retrospective** letter. In **forward** mode the `step4-cover-letter-forward` agent is authoritative instead: it produces a dual-anchored first-90-days plan with a First-90-Days Plan table and "How I'd approach X:" paragraphs. The contact header (above), voice discipline, and provenance rules are shared across both modes; the seven-element structure and Requirements Alignment table below do **not** apply to a forward letter.
 
 The agent writes the body in this order. Each element is mandatory unless explicitly marked optional in the agent.
 

--- a/plugins/jobops/skills/setup/SKILL.md
+++ b/plugins/jobops/skills/setup/SKILL.md
@@ -78,6 +78,13 @@ Ask in order:
 2. **Default jurisdiction** — ISO 3166-2 code (e.g., `CA-ON`, `US-CA`).
    Default `CA-ON`. Used by crisis skills; they accept
    `--jurisdiction=<code>` to override per-invocation.
+3. **Cover letter mode** — enum `retrospective` | `forward`. Default `retrospective`.
+   Controls how `/jobops:coverletter` writes the letter. `retrospective` maps the job's
+   requirements to what the candidate has already done. `forward` proposes what the
+   candidate would do in the first 90 days, tying each action to a real problem the role
+   faces and to past work that proves the candidate can do it; it runs a short interview
+   each time it is used. Override per-invocation with
+   `/jobops:coverletter --mode=retrospective|forward`.
 
 Do **not** ask for `default_currency` here — that is owned by `/jobops-ic:setup`
 (see Step 4 of that flow).
@@ -153,7 +160,8 @@ Emit the full schema below with the values gathered in Steps 2 and 4.
   },
   "preferences": {
     "cultural_profile": "<step-4 value>",
-    "default_jurisdiction": "<step-4 value>"
+    "default_jurisdiction": "<step-4 value>",
+    "cover_letter_mode": "<step-4 value>"
   },
   "candidate": {
     "name": "<step-4b value>",


### PR DESCRIPTION
## Summary

Adds a config-selectable **forward-facing cover letter mode** alongside the existing retrospective mode. Instead of matching the job's requirements to past work, forward mode proposes a **dual-anchored first-90-days plan**: every proposed action sits on a *real problem* (traceable to a verified primary source or the JD, never speculation) **and** a *concrete past proof point*.

- **Selection:** `preferences.cover_letter_mode` (`retrospective` default | `forward`), overridable per-invocation with `/jobops:coverletter --mode=forward`. Configs lacking the key behave exactly as before.
- **Mandatory intake interview:** because the agent runs non-interactively, `/coverletter` runs a five-question interview (primed cheaply from the JD + existing OSINT) before dispatching the new `step4-cover-letter-forward` agent.
- **New agent `step4-cover-letter-forward.md`:** self-contained sibling reproducing the shared rules (contact header, Step 3a primary-source verification, voice/style, banned list, Step 6a sub-agent review). Forward-specific changes: a First-90-Days Plan table (`problem → action → proof`), "How I'd approach X:" paragraphs, a layered-horizon close (90 days + 6–12 month arc), a narrowed future-tense ban (allowed only when dual-anchored), and a dual-anchor reviewer check that cuts any forward claim lacking a proof anchor or aimed at an unverifiable problem.
- **Retrospective mode is untouched** — `step4-cover-letter.md` has zero diff against main.
- Docs (ARCHITECTURE config contract, README, CLAUDE.md agent-pairing note) and version bump to **v2.13.0**.

Spec: `docs/superpowers/specs/2026-06-01-forward-facing-cover-letter-mode-design.md`
Plan: `docs/superpowers/plans/2026-06-01-forward-facing-cover-letter-mode.md`

## Test Plan

- [x] `npm test` (Codex compatibility contract) passes
- [x] `claude plugin validate plugins/jobops`, `plugins/jobops-ic`, and `.` all pass
- [x] Routing traced for all four scenarios (config-forward, flag-override, missing-key, invalid-flag) — see `docs/superpowers/plans/2026-06-01-forward-facing-cover-letter-mode-verification.md`
- [x] Dual-anchor guardrail confirmed consistent across §3a Step 5, §4.4, and §6a
- [x] Forward exemplar is em-dash-free and demonstrates the dual anchor
- [ ] Manual: run `/jobops:coverletter --mode=forward` against a real JD and confirm the interview + dual-anchored output

🤖 Generated with [Claude Code](https://claude.com/claude-code)